### PR TITLE
API: Update server API to provide sample transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# budget-robot
+# Budget Robot
+
+Right now this is a small script (and API) to help with **my family budget**. The goal is to make that workflow **as easy as possible**.
+
+## Install
+
+1. **Rust** — Install the stable toolchain with [rustup](https://rustup.rs/) so you have `cargo` on your PATH.
+2. **This repo** — Clone it (or download it), then from the repo root:
+
+```bash
+cd server
+cargo build
+```
+
+The first `cargo build` (or `cargo run`) downloads dependencies and compiles the server.
+
+## How to run
+
+```bash
+cd server
+cargo run
+```
+
+Open **http://127.0.0.1:3055/transactions/sample** for JSON with sample `transactions`.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,28 +1,64 @@
-//! Minimal HTTP API: JSON on `GET /`.
+//! Minimal HTTP API: sample transactions JSON on `GET /transactions/sample`.
 
 use actix_web::{web, App, HttpServer, Responder};
 use serde::Serialize;
 
-/// Body returned for `GET /` (`Content-Type: application/json`).
+/// One row; JSON keys match spreadsheet/CSV headers for easy export or hand-editing.
 #[derive(Serialize)]
-struct HelloResponse {
-    message: &'static str,
+struct Transaction {
+    #[serde(rename = "Date")]
+    date: String,
+    #[serde(rename = "Description")]
+    description: String,
+    #[serde(rename = "Amount")]
+    amount: f64,
+    #[serde(rename = "Category")]
+    category: String,
 }
 
-/// Serves `{"message":"hello world"}`.
-async fn hello() -> impl Responder {
-    web::Json(HelloResponse {
-        message: "hello world",
+/// Sample transactions response
+#[derive(Serialize)]
+struct SampleTransactionsResponse {
+    transactions: Vec<Transaction>,
+}
+
+/// Sample transactions for development (English JSON keys, CSV-friendly).
+fn sample_transactions() -> Vec<Transaction> {
+    vec![
+        Transaction {
+            date: "2024-01-15".into(),
+            description: "STARBUCKS STORE #4521".into(),
+            amount: 12.34,
+            category: "Restaurant".into(),
+        },
+        Transaction {
+            date: "2024-01-16".into(),
+            description: "IGA SUPERMARKT".into(),
+            amount: 56.78,
+            category: "Grocery".into(),
+        },
+    ]
+}
+
+/// Sample transactions for development (English JSON keys, CSV-friendly).
+async fn transactions_sample() -> impl Responder {
+    web::Json(SampleTransactionsResponse {
+        transactions: sample_transactions(),
     })
 }
 
+/// Main function
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // Host/port the process listens on (change if 3055 is taken).
     let addr = "127.0.0.1:3055";
-    println!("Server listening on http://{addr}/");
+    println!("Server listening on http://{addr}/transactions/sample");
 
-    HttpServer::new(|| App::new().route("/", web::get().to(hello)))
+    HttpServer::new(|| {
+        App::new().route(
+            "/transactions/sample",
+            web::get().to(transactions_sample),
+        )
+    })
         .bind(addr)?
         .run()
         .await


### PR DESCRIPTION
# Issue

## Description
API: Update server API to provide sample transactions
- Added instructions on how to install and run the server.
- Updated the server API to return sample transaction data at the endpoint '/transactions/sample' instead of a simple hello message.
- Introduced a new data structure for transactions with fields for date, description, amount, and category.