### PR TITLE
Feature: Add .vscode/tasks.json for server/client dev loop

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,89 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Client and Server",
+      "dependsOn": [
+        "Run Server",
+        "Run Client"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run Server",
+      "type": "shell",
+      "command": "cargo",
+      "args": ["watch", "-x", "run"],
+      "options": {
+        "cwd": "${workspaceFolder}/server"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run Client",
+      "type": "shell",
+      "command": "echo 'TODO: no client app yet - replace with the real start command once client/ exists'",
+      "options": {
+        "cwd": "${workspaceFolder}/client"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Format",
+      "dependsOn": ["Format Server", "Format Client"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Format Server",
+      "type": "shell",
+      "command": "cargo",
+      "args": ["fmt"],
+      "options": {
+        "cwd": "${workspaceFolder}/server"
+      },
+      "group": "build"
+    },
+    {
+      "label": "Format Client",
+      "type": "shell",
+      "command": "echo 'TODO: no client app yet - replace with the real format command once client/ exists'",
+      "options": {
+        "cwd": "${workspaceFolder}/client"
+      },
+      "group": "build"
+    },
+    {
+      "label": "Update Main",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Git Checkout Main",
+        "Git Pull Main"
+      ],
+      "group": "build"
+    },
+    {
+      "label": "Git Checkout Main",
+      "type": "shell",
+      "command": "git checkout main",
+      "group": "build"
+    },
+    {
+      "label": "Git Pull Main",
+      "type": "shell",
+      "command": "git pull origin main",
+      "group": "build"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 
 1. **Rust** — Install the stable toolchain with [rustup](https://rustup.rs/) so you have `cargo` on your PATH.
 2. **PostgreSQL** — Install it and have a server running locally (e.g. `sudo apt install postgresql`. Create a database for this project (any name, matched to `DATABASE_URL` below).
-3. **This repo** — Clone it (or download it), then from the repo root:
+3. **cargo-watch** (used by the VS Code "Run Server" task for auto-reload on save) — `cargo install cargo-watch`.
+4. **This repo** — Clone it (or download it), then from the repo root:
 
 ```bash
 cd server
@@ -38,8 +39,10 @@ cp .env.example .env
 
 ```bash
 cd server
-cargo run
+cargo watch -x run # Or `cargo run` for a single run without auto-reload.
 ```
+
+Or use the VS Code "Run Server" task for auto-reload on save.
 
 ## API
 


### PR DESCRIPTION
Adds tasks to run server + client (in parallel), format server + client (in parallel), and update main from origin. Server task uses cargo-watch for auto-reload; a plain cargo run migrates the DB automatically already, so no separate migrate task is needed.

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VS Code tasks for running the server, formatting code, coordinating client and server workflows, and updating the main branch.
  * Added server auto-reload support through `cargo-watch`.

* **Documentation**
  * Updated setup instructions to include installing `cargo-watch`.
  * Added guidance for running the server with auto-reload and using the VS Code server task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->