### PR TITLE
Chore: Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Samuel Duhaime-Morissette
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [How to run](#how-to-run)
 - [API](#api)
 - [Tests](#tests)
+- [License](#license)
 
 ## Install
 
@@ -74,3 +75,7 @@ cargo test
 ```
 
 Each test runs against its own throwaway Postgres database (auto-migrated, auto-dropped), so your real data is untouched.
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Add `LICENSE` file (MIT, 2026, Samuel Duhaime-Morissette)
- Add a License section to the README linking to it

Closes #30

## Test plan
- [x] `LICENSE` file present at repo root
- [x] README links to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a License section to the README with a link to the full license text.
  * Added the project’s MIT License information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->