### PR TITLE
Feature: Add transaction list grouped by date to Transactions page

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,7 +17,8 @@
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-router": "^1.170.18",
         "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react-dom": "^19.2.7",
+        "sonner": "^2.0.7"
       },
       "devDependencies": {
         "@tanstack/react-query-devtools": "^5.101.2",
@@ -2259,6 +2260,16 @@
       },
       "peerDependencies": {
         "seroval": "^1.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,8 @@
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.18",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
     "@tanstack/react-query-devtools": "^5.101.2",

--- a/client/src/components/LeftMenu.css
+++ b/client/src/components/LeftMenu.css
@@ -3,9 +3,30 @@
   flex-direction: column;
   width: 220px;
   flex-shrink: 0;
-  height: calc(100vh - 60px);
+  height: 100%;
   padding: var(--spacing-s) var(--spacing-s) var(--spacing-l);
   background: var(--color-background);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-medium) transparent;
+}
+
+.left-menu::-webkit-scrollbar {
+  width: 10px;
+}
+
+.left-menu::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.left-menu::-webkit-scrollbar-thumb {
+  background-color: var(--color-medium);
+  border-radius: var(--spacing-s);
+  border: 2px solid var(--color-background);
+}
+
+.left-menu::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-light);
 }
 
 .left-menu-nav {

--- a/client/src/components/Popover.css
+++ b/client/src/components/Popover.css
@@ -1,0 +1,10 @@
+.anchored-popover {
+  position: fixed;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-dark);
+  border: 1px solid var(--color-medium);
+  border-radius: var(--spacing-xs);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}

--- a/client/src/components/TopMenu.css
+++ b/client/src/components/TopMenu.css
@@ -33,6 +33,7 @@
 
 .top-menu-title {
   margin: 0;
+  margin-right: var(--spacing-m);
   font-size: 24px;
 }
 
@@ -41,4 +42,21 @@
   align-items: center;
   gap: var(--spacing-s);
   margin-left: auto;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-medium) transparent;
+}
+
+.top-menu-actions::-webkit-scrollbar {
+  height: 6px;
+}
+
+.top-menu-actions::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.top-menu-actions::-webkit-scrollbar-thumb {
+  background-color: var(--color-medium);
+  border-radius: var(--spacing-s);
 }

--- a/client/src/components/TopMenu.css
+++ b/client/src/components/TopMenu.css
@@ -60,3 +60,18 @@
   background-color: var(--color-medium);
   border-radius: var(--spacing-s);
 }
+
+.top-menu-clear-all {
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--color-lightest);
+  font: 700 15px/normal 'Quicksand', sans-serif;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.top-menu-clear-all:hover,
+.top-menu-clear-all:focus-visible {
+  color: var(--color-white);
+}

--- a/client/src/components/TopMenu.css
+++ b/client/src/components/TopMenu.css
@@ -23,7 +23,7 @@
 
 .top-menu-logo-text {
   margin: 0;
-  font: 700 24px/normal 'Nunito', sans-serif;
+  font: 700 24px/normal Nunito, sans-serif;
   color: var(--color-white);
 }
 
@@ -66,7 +66,7 @@
   background: none;
   padding: 0;
   color: var(--color-lightest);
-  font: 700 15px/normal 'Quicksand', sans-serif;
+  font: 700 15px/normal Quicksand, sans-serif;
   cursor: pointer;
   transition: color 0.15s ease;
 }

--- a/client/src/components/TopMenuButton.css
+++ b/client/src/components/TopMenuButton.css
@@ -24,5 +24,4 @@
 
 .top-menu-button--primary {
   background: var(--color-primary);
-  color: var(--color-black);
 }

--- a/client/src/components/TopMenuButton.css
+++ b/client/src/components/TopMenuButton.css
@@ -4,10 +4,10 @@
   gap: var(--spacing-xs);
   padding: var(--spacing-xs) var(--spacing-s);
   border: none;
-  border-radius: var(--spacing-s);
+  border-radius: var(--spacing-xs);
   background: var(--color-dark);
   color: var(--color-white);
-  font: 700 22px/normal 'Quicksand', sans-serif;
+  font: 700 15px/normal 'Quicksand', sans-serif;
   cursor: pointer;
   transition: filter 0.15s ease;
 }

--- a/client/src/components/TopMenuButton.css
+++ b/client/src/components/TopMenuButton.css
@@ -7,7 +7,7 @@
   border-radius: var(--spacing-xs);
   background: var(--color-dark);
   color: var(--color-white);
-  font: 700 15px/normal 'Quicksand', sans-serif;
+  font: 700 15px/normal Quicksand, sans-serif;
   cursor: pointer;
   transition: filter 0.15s ease;
 }

--- a/client/src/features/transactions/SearchButton.css
+++ b/client/src/features/transactions/SearchButton.css
@@ -30,7 +30,7 @@
   border-radius: var(--spacing-xs);
   background: var(--color-background);
   color: var(--color-white);
-  font: 400 16px/1.5 'Quicksand', sans-serif;
+  font: 400 16px/1.5 Quicksand, sans-serif;
 }
 
 .search-popover-input:focus-visible {
@@ -58,7 +58,7 @@
   border-radius: var(--spacing-xs);
   background: var(--color-medium);
   color: var(--color-white);
-  font: 700 15px/normal 'Quicksand', sans-serif;
+  font: 700 15px/normal Quicksand, sans-serif;
   cursor: pointer;
   transition: filter 0.15s ease;
 }

--- a/client/src/features/transactions/SearchButton.css
+++ b/client/src/features/transactions/SearchButton.css
@@ -1,0 +1,113 @@
+.search-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.search-button-clear-applied {
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--color-lightest);
+  font: 700 15px/normal 'Quicksand', sans-serif;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.search-button-clear-applied:hover,
+.search-button-clear-applied:focus-visible {
+  color: var(--color-white);
+}
+
+.search-button-trigger {
+  position: relative;
+  display: inline-flex;
+}
+
+.search-button-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  border: 2px solid var(--color-background);
+}
+
+.search-popover {
+  position: fixed;
+  z-index: 1000;
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-s);
+  background: var(--color-dark);
+  border: 1px solid var(--color-medium);
+  border-radius: var(--spacing-xs);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.search-popover-title {
+  margin: 0;
+}
+
+.search-popover-input {
+  padding: var(--spacing-xs) var(--spacing-s);
+  border: 1px solid var(--color-light);
+  border-radius: var(--spacing-xs);
+  background: var(--color-background);
+  color: var(--color-white);
+  font: 400 16px/1.5 'Quicksand', sans-serif;
+}
+
+.search-popover-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.search-popover-help {
+  margin: 0;
+  color: var(--color-lightest);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.search-popover-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-xs);
+}
+
+.search-popover-button {
+  padding: var(--spacing-xs) var(--spacing-s);
+  border: none;
+  border-radius: var(--spacing-xs);
+  background: var(--color-medium);
+  color: var(--color-white);
+  font: 700 15px/normal 'Quicksand', sans-serif;
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+
+.search-popover-button:hover:not(:disabled),
+.search-popover-button:focus-visible:not(:disabled) {
+  filter: brightness(1.2);
+}
+
+.search-popover-button:focus-visible {
+  outline: 2px solid var(--color-white);
+  outline-offset: 2px;
+}
+
+.search-popover-button--primary {
+  background: var(--color-primary);
+}
+
+.search-popover-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/client/src/features/transactions/SearchButton.css
+++ b/client/src/features/transactions/SearchButton.css
@@ -1,25 +1,3 @@
-.search-button {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-}
-
-.search-button-clear-applied {
-  border: none;
-  background: none;
-  padding: 0;
-  color: var(--color-lightest);
-  font: 700 15px/normal 'Quicksand', sans-serif;
-  cursor: pointer;
-  transition: color 0.15s ease;
-}
-
-.search-button-clear-applied:hover,
-.search-button-clear-applied:focus-visible {
-  color: var(--color-white);
-}
-
 .search-button-trigger {
   position: relative;
   display: inline-flex;
@@ -37,17 +15,9 @@
 }
 
 .search-popover {
-  position: fixed;
-  z-index: 1000;
   width: 320px;
-  display: flex;
-  flex-direction: column;
   gap: var(--spacing-xs);
   padding: var(--spacing-s);
-  background: var(--color-dark);
-  border: 1px solid var(--color-medium);
-  border-radius: var(--spacing-xs);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 .search-popover-title {

--- a/client/src/features/transactions/SearchButton.tsx
+++ b/client/src/features/transactions/SearchButton.tsx
@@ -24,16 +24,19 @@ export const SearchButton = () => {
   };
 
   const isDraftEmpty = draft.trim() === '';
+  const hasNothingToClear = isDraftEmpty && !search;
 
   const handleApply = () => {
-    if (isDraftEmpty) return;
-    applySearch(draft.trim());
+    if (hasNothingToClear) return;
+    applySearch(isDraftEmpty ? undefined : draft.trim());
     setIsOpen(false);
   };
 
   const handleClearDraft = () => {
-    if (isDraftEmpty) return;
+    if (hasNothingToClear) return;
     setDraft('');
+    applySearch(undefined);
+    setIsOpen(false);
   };
 
   const handleCancel = () => {
@@ -78,7 +81,7 @@ export const SearchButton = () => {
               <button
                 type="button"
                 className="search-popover-button"
-                disabled={isDraftEmpty}
+                disabled={hasNothingToClear}
                 onClick={handleClearDraft}
               >
                 Clear
@@ -89,7 +92,7 @@ export const SearchButton = () => {
               <button
                 type="button"
                 className="search-popover-button search-popover-button--primary"
-                disabled={isDraftEmpty}
+                disabled={hasNothingToClear}
                 onClick={handleApply}
               >
                 Apply

--- a/client/src/features/transactions/SearchButton.tsx
+++ b/client/src/features/transactions/SearchButton.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { getRouteApi } from '@tanstack/react-router';
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { TopMenuButton } from '../../components/TopMenuButton';
+import './SearchButton.css';
+
+const routeApi = getRouteApi('/transactions');
+
+type Position = { top: number; left: number };
+
+export const SearchButton = () => {
+  const { search } = routeApi.useSearch();
+  const navigate = routeApi.useNavigate();
+  const [isOpen, setIsOpen] = useState(false);
+  const [draft, setDraft] = useState(search ?? '');
+  const [position, setPosition] = useState<Position | null>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen) setDraft(search ?? '');
+  }, [isOpen, search]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const updatePosition = () => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (rect) setPosition({ top: rect.bottom + 8, left: rect.left });
+    };
+    updatePosition();
+
+    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('resize', updatePosition);
+    return () => {
+      window.removeEventListener('scroll', updatePosition, true);
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target) || popoverRef.current?.contains(target)) return;
+      setIsOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  const applySearch = (term: string | undefined) => {
+    navigate({ search: (prev) => ({ ...prev, search: term }), replace: true });
+  };
+
+  const isDraftEmpty = draft.trim() === '';
+
+  const handleApply = () => {
+    if (isDraftEmpty) return;
+    applySearch(draft.trim());
+    setIsOpen(false);
+  };
+
+  const handleClearDraft = () => {
+    if (isDraftEmpty) return;
+    setDraft('');
+  };
+
+  const handleCancel = () => {
+    setDraft(search ?? '');
+    setIsOpen(false);
+  };
+
+  const handleClearApplied = () => applySearch(undefined);
+
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') handleApply();
+  };
+
+  return (
+    <div className="search-button">
+      {search && (
+        <button type="button" className="search-button-clear-applied" onClick={handleClearApplied}>
+          Clear
+        </button>
+      )}
+      <div className="search-button-trigger" ref={triggerRef}>
+        <TopMenuButton
+          icon={faMagnifyingGlass}
+          label={search ? `"${search}"` : 'Search'}
+          onClick={() => setIsOpen((open) => !open)}
+        />
+        {search && <span className="search-button-badge" />}
+      </div>
+      {isOpen &&
+        position &&
+        createPortal(
+          <div
+            className="search-popover"
+            ref={popoverRef}
+            style={{ top: position.top, left: position.left }}
+          >
+            <h4 className="search-popover-title">Search</h4>
+            <input
+              type="text"
+              className="search-popover-input"
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={handleInputKeyDown}
+              placeholder="Enter a search term..."
+              autoFocus
+            />
+            <p className="search-popover-help">
+              We&apos;ll match your search term to merchant names, categories, and amounts.
+            </p>
+            <div className="search-popover-actions">
+              <button
+                type="button"
+                className="search-popover-button"
+                disabled={isDraftEmpty}
+                onClick={handleClearDraft}
+              >
+                Clear
+              </button>
+              <button type="button" className="search-popover-button" onClick={handleCancel}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="search-popover-button search-popover-button--primary"
+                disabled={isDraftEmpty}
+                onClick={handleApply}
+              >
+                Apply
+              </button>
+            </div>
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+};

--- a/client/src/features/transactions/SearchButton.tsx
+++ b/client/src/features/transactions/SearchButton.tsx
@@ -1,63 +1,23 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { getRouteApi } from '@tanstack/react-router';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import { TopMenuButton } from '../../components/TopMenuButton';
+import { useAnchoredPopover } from '../../lib/use-anchored-popover';
+import '../../components/Popover.css';
 import './SearchButton.css';
 
 const routeApi = getRouteApi('/transactions');
 
-type Position = { top: number; left: number };
-
 export const SearchButton = () => {
   const { search } = routeApi.useSearch();
   const navigate = routeApi.useNavigate();
-  const [isOpen, setIsOpen] = useState(false);
+  const { isOpen, setIsOpen, position, triggerRef, popoverRef } = useAnchoredPopover();
   const [draft, setDraft] = useState(search ?? '');
-  const [position, setPosition] = useState<Position | null>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (isOpen) setDraft(search ?? '');
   }, [isOpen, search]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const updatePosition = () => {
-      const rect = triggerRef.current?.getBoundingClientRect();
-      if (rect) setPosition({ top: rect.bottom + 8, left: rect.left });
-    };
-    updatePosition();
-
-    window.addEventListener('scroll', updatePosition, true);
-    window.addEventListener('resize', updatePosition);
-    return () => {
-      window.removeEventListener('scroll', updatePosition, true);
-      window.removeEventListener('resize', updatePosition);
-    };
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handlePointerDown = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (triggerRef.current?.contains(target) || popoverRef.current?.contains(target)) return;
-      setIsOpen(false);
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setIsOpen(false);
-    };
-
-    document.addEventListener('mousedown', handlePointerDown);
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [isOpen]);
 
   const applySearch = (term: string | undefined) => {
     navigate({ search: (prev) => ({ ...prev, search: term }), replace: true });
@@ -81,32 +41,23 @@ export const SearchButton = () => {
     setIsOpen(false);
   };
 
-  const handleClearApplied = () => applySearch(undefined);
-
   const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') handleApply();
   };
 
   return (
-    <div className="search-button">
-      {search && (
-        <button type="button" className="search-button-clear-applied" onClick={handleClearApplied}>
-          Clear
-        </button>
-      )}
-      <div className="search-button-trigger" ref={triggerRef}>
-        <TopMenuButton
-          icon={faMagnifyingGlass}
-          label={search ? `"${search}"` : 'Search'}
-          onClick={() => setIsOpen((open) => !open)}
-        />
-        {search && <span className="search-button-badge" />}
-      </div>
+    <div className="search-button-trigger" ref={triggerRef}>
+      <TopMenuButton
+        icon={faMagnifyingGlass}
+        label={search ? `"${search}"` : 'Search'}
+        onClick={() => setIsOpen((open) => !open)}
+      />
+      {search && <span className="search-button-badge" />}
       {isOpen &&
         position &&
         createPortal(
           <div
-            className="search-popover"
+            className="anchored-popover search-popover"
             ref={popoverRef}
             style={{ top: position.top, left: position.left }}
           >

--- a/client/src/features/transactions/SortButton.css
+++ b/client/src/features/transactions/SortButton.css
@@ -27,7 +27,7 @@
   border-radius: var(--spacing-xs);
   background: none;
   color: var(--color-white);
-  font: 400 15px/1.5 'Quicksand', sans-serif;
+  font: 400 15px/1.5 Quicksand, sans-serif;
   text-align: left;
   cursor: pointer;
   transition: background-color 0.15s ease;

--- a/client/src/features/transactions/SortButton.css
+++ b/client/src/features/transactions/SortButton.css
@@ -1,0 +1,45 @@
+.sort-button-trigger {
+  position: relative;
+}
+
+.sort-button-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  border: 2px solid var(--color-dark);
+}
+
+.sort-popover {
+  width: 220px;
+  padding: var(--spacing-xs);
+  gap: 2px;
+}
+
+.sort-popover-option {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-xs) var(--spacing-s);
+  border: none;
+  border-radius: var(--spacing-xs);
+  background: none;
+  color: var(--color-white);
+  font: 400 15px/1.5 'Quicksand', sans-serif;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.sort-popover-option:hover,
+.sort-popover-option:focus-visible {
+  background: var(--color-medium);
+}
+
+.sort-popover-option--selected,
+.sort-popover-option--selected:hover,
+.sort-popover-option--selected:focus-visible {
+  background: color-mix(in srgb, var(--color-primary) 30%, var(--color-dark));
+}

--- a/client/src/features/transactions/SortButton.tsx
+++ b/client/src/features/transactions/SortButton.tsx
@@ -1,0 +1,72 @@
+import { createPortal } from 'react-dom';
+import { getRouteApi } from '@tanstack/react-router';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { useAnchoredPopover } from '../../lib/use-anchored-popover';
+import type { SortOrder } from './types';
+import '../../components/Popover.css';
+import './SortButton.css';
+
+const routeApi = getRouteApi('/transactions');
+
+const SORT_OPTIONS: { value: SortOrder; label: string }[] = [
+  { value: 'date', label: 'Date (new to old)' },
+  { value: 'inverse_date', label: 'Date (old to new)' },
+  { value: 'amount', label: 'Amount (high to low)' },
+  { value: 'inverse_amount', label: 'Amount (low to high)' },
+];
+
+export const SortButton = () => {
+  const { order } = routeApi.useSearch();
+  const navigate = routeApi.useNavigate();
+  const { isOpen, setIsOpen, position, triggerRef, popoverRef } =
+    useAnchoredPopover<HTMLButtonElement>();
+
+  const selected = order ?? 'date';
+  const isActive = selected !== 'date';
+
+  const handleSelect = (value: SortOrder) => {
+    navigate({ search: (prev) => ({ ...prev, order: value }), replace: true });
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="transactions-toolbar-button sort-button-trigger"
+        ref={triggerRef}
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        <span>Sort</span>
+        <FontAwesomeIcon icon={faChevronDown} />
+        {isActive && <span className="sort-button-badge" />}
+      </button>
+      {isOpen &&
+        position &&
+        createPortal(
+          <div
+            className="anchored-popover sort-popover"
+            ref={popoverRef}
+            style={{ top: position.top, left: position.left }}
+          >
+            {SORT_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={
+                  option.value === selected
+                    ? 'sort-popover-option sort-popover-option--selected'
+                    : 'sort-popover-option'
+                }
+                onClick={() => handleSelect(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+};

--- a/client/src/features/transactions/TransactionsList.css
+++ b/client/src/features/transactions/TransactionsList.css
@@ -15,6 +15,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  overflow-x: auto;
 }
 
 .transactions-date-header {
@@ -24,14 +25,16 @@
   background: color-mix(in srgb, var(--color-medium) 40%, var(--color-dark));
   color: var(--color-lightest);
   font-size: 15px;
+  min-width: 520px;
 }
 
 .transactions-row {
   display: grid;
-  grid-template-columns: 2fr 1.5fr 1.5fr 110px 16px;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 1.5fr) 110px 16px;
   align-items: center;
   gap: var(--spacing-s);
   padding: var(--spacing-s);
+  min-width: 520px;
   transition: filter 0.15s ease;
 }
 

--- a/client/src/features/transactions/TransactionsList.css
+++ b/client/src/features/transactions/TransactionsList.css
@@ -1,0 +1,64 @@
+.transactions-card {
+  border-radius: var(--spacing-s);
+  overflow: hidden;
+  background: var(--color-dark);
+}
+
+.transactions-status {
+  margin: 0;
+  padding: var(--spacing-s);
+}
+
+.transactions-rows {
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.transactions-date-header {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--spacing-xs) var(--spacing-s);
+  background: color-mix(in srgb, var(--color-medium) 40%, var(--color-dark));
+  color: var(--color-lightest);
+  font-size: 15px;
+}
+
+.transactions-row {
+  display: grid;
+  grid-template-columns: 2fr 1.5fr 1.5fr 110px 16px;
+  align-items: center;
+  gap: var(--spacing-s);
+  padding: var(--spacing-s);
+  transition: filter 0.15s ease;
+}
+
+.transactions-row:hover {
+  filter: brightness(1.2);
+}
+
+.transactions-row-cell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.transactions-row-account {
+  color: var(--color-lightest);
+}
+
+.transactions-row-amount {
+  font-weight: 700;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.transactions-row-amount--credit {
+  color: var(--color-success);
+}
+
+.transactions-row-chevron {
+  color: var(--color-light);
+}

--- a/client/src/features/transactions/TransactionsList.tsx
+++ b/client/src/features/transactions/TransactionsList.tsx
@@ -8,7 +8,7 @@ import { formatAmount, formatDateHeading } from './format';
 import type { Transaction } from './types';
 import './TransactionsList.css';
 
-/** Groups transactions by date, assuming they already arrive sorted by date (most recent first). */
+/** Groups transactions by date, assuming they already arrive sorted with same-date rows adjacent. */
 const groupByDate = (transactions: Transaction[]): { date: string; transactions: Transaction[] }[] => {
   const groups: { date: string; transactions: Transaction[] }[] = [];
   for (const transaction of transactions) {
@@ -48,8 +48,8 @@ const TransactionRow = ({ transaction }: { transaction: Transaction }) => {
 const routeApi = getRouteApi('/transactions');
 
 export const TransactionsList = () => {
-  const { search } = routeApi.useSearch();
-  const { data: transactions, isPending, isError } = useTransactions(search);
+  const { search, order } = routeApi.useSearch();
+  const { data: transactions, isPending, isError } = useTransactions(search, order);
 
   return (
     <div className="transactions-card">
@@ -59,8 +59,8 @@ export const TransactionsList = () => {
       {transactions && transactions.length === 0 && <p className="transactions-status">No transactions yet.</p>}
       {transactions && transactions.length > 0 && (
         <ul className="transactions-rows">
-          {groupByDate(transactions).map((group) => (
-            <Fragment key={group.date}>
+          {groupByDate(transactions).map((group, index) => (
+            <Fragment key={`${group.date}-${index}`}>
               <li className="transactions-date-header">
                 <span>{formatDateHeading(group.date)}</span>
                 <span>{formatAmount(dailyTotal(group.transactions))}</span>

--- a/client/src/features/transactions/TransactionsList.tsx
+++ b/client/src/features/transactions/TransactionsList.tsx
@@ -1,0 +1,73 @@
+import { Fragment } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTransactions } from './use-transactions';
+import { TransactionsToolbar } from './TransactionsToolbar';
+import { formatAmount, formatDateHeading } from './format';
+import type { Transaction } from './types';
+import './TransactionsList.css';
+
+/** Groups transactions by date, assuming they already arrive sorted by date (most recent first). */
+const groupByDate = (transactions: Transaction[]): { date: string; transactions: Transaction[] }[] => {
+  const groups: { date: string; transactions: Transaction[] }[] = [];
+  for (const transaction of transactions) {
+    const currentGroup = groups.at(-1);
+    if (currentGroup?.date === transaction.date) {
+      currentGroup.transactions.push(transaction);
+    } else {
+      groups.push({ date: transaction.date, transactions: [transaction] });
+    }
+  }
+  return groups;
+};
+
+/** A day's total is its net spend: credits (income/transfers) don't offset expenses. */
+const dailyTotal = (transactions: Transaction[]): number =>
+  transactions
+    .filter((transaction) => transaction.category_type === 'expense')
+    .reduce((sum, transaction) => sum + Number(transaction.amount), 0);
+
+const TransactionRow = ({ transaction }: { transaction: Transaction }) => {
+  const isCredit = transaction.category_type !== 'expense';
+
+  return (
+    <li className="transactions-row">
+      <div className="transactions-row-cell transactions-row-merchant">{transaction.merchant}</div>
+      <div className="transactions-row-cell transactions-row-category">{transaction.category_name_en}</div>
+      <div className="transactions-row-cell transactions-row-account">{transaction.account}</div>
+      <div className={isCredit ? 'transactions-row-amount transactions-row-amount--credit' : 'transactions-row-amount'}>
+        {isCredit ? '+' : ''}
+        {formatAmount(Number(transaction.amount))}
+      </div>
+      <FontAwesomeIcon icon={faChevronRight} className="transactions-row-chevron" />
+    </li>
+  );
+};
+
+export const TransactionsList = () => {
+  const { data: transactions, isPending, isError } = useTransactions();
+
+  return (
+    <div className="transactions-card">
+      <TransactionsToolbar />
+      {isPending && <p className="transactions-status">Loading transactions…</p>}
+      {isError && <p className="transactions-status">Failed to load transactions.</p>}
+      {transactions && transactions.length === 0 && <p className="transactions-status">No transactions yet.</p>}
+      {transactions && transactions.length > 0 && (
+        <ul className="transactions-rows">
+          {groupByDate(transactions).map((group) => (
+            <Fragment key={group.date}>
+              <li className="transactions-date-header">
+                <span>{formatDateHeading(group.date)}</span>
+                <span>{formatAmount(dailyTotal(group.transactions))}</span>
+              </li>
+              {group.transactions.map((transaction) => (
+                <TransactionRow key={transaction.id} transaction={transaction} />
+              ))}
+            </Fragment>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/client/src/features/transactions/TransactionsList.tsx
+++ b/client/src/features/transactions/TransactionsList.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from 'react';
+import { getRouteApi } from '@tanstack/react-router';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTransactions } from './use-transactions';
@@ -44,8 +45,11 @@ const TransactionRow = ({ transaction }: { transaction: Transaction }) => {
   );
 };
 
+const routeApi = getRouteApi('/transactions');
+
 export const TransactionsList = () => {
-  const { data: transactions, isPending, isError } = useTransactions();
+  const { search } = routeApi.useSearch();
+  const { data: transactions, isPending, isError } = useTransactions(search);
 
   return (
     <div className="transactions-card">

--- a/client/src/features/transactions/TransactionsToolbar.css
+++ b/client/src/features/transactions/TransactionsToolbar.css
@@ -23,7 +23,7 @@
   border-radius: var(--spacing-xs);
   background: var(--color-medium);
   color: var(--color-white);
-  font: 700 15px/normal 'Quicksand', sans-serif;
+  font: 700 15px/normal Quicksand, sans-serif;
   cursor: pointer;
   transition: filter 0.15s ease;
 }

--- a/client/src/features/transactions/TransactionsToolbar.css
+++ b/client/src/features/transactions/TransactionsToolbar.css
@@ -1,5 +1,6 @@
 .transactions-toolbar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-s);
@@ -8,6 +9,7 @@
 
 .transactions-toolbar-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--spacing-s);
 }

--- a/client/src/features/transactions/TransactionsToolbar.css
+++ b/client/src/features/transactions/TransactionsToolbar.css
@@ -1,0 +1,43 @@
+.transactions-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+  padding: var(--spacing-s);
+}
+
+.transactions-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+.transactions-toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-s);
+  border: none;
+  border-radius: var(--spacing-xs);
+  background: var(--color-medium);
+  color: var(--color-white);
+  font: 700 15px/normal 'Quicksand', sans-serif;
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+
+.transactions-toolbar-button:hover,
+.transactions-toolbar-button:focus-visible {
+  filter: brightness(1.2);
+}
+
+.transactions-toolbar-button:focus-visible {
+  outline: 2px solid var(--color-white);
+  outline-offset: 2px;
+}
+
+.transactions-toolbar-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--color-medium);
+}

--- a/client/src/features/transactions/TransactionsToolbar.tsx
+++ b/client/src/features/transactions/TransactionsToolbar.tsx
@@ -1,0 +1,27 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown, faSquareCheck, faTableColumns } from '@fortawesome/free-solid-svg-icons';
+import './TransactionsToolbar.css';
+
+export const TransactionsToolbar = () => (
+  <div className="transactions-toolbar">
+    <button type="button" className="transactions-toolbar-button">
+      <span>All transactions</span>
+      <FontAwesomeIcon icon={faChevronDown} />
+    </button>
+    <div className="transactions-toolbar-actions">
+      <button type="button" className="transactions-toolbar-button">
+        <FontAwesomeIcon icon={faSquareCheck} />
+        <span>Edit multiple</span>
+      </button>
+      <span className="transactions-toolbar-divider" />
+      <button type="button" className="transactions-toolbar-button">
+        <span>Sort</span>
+        <FontAwesomeIcon icon={faChevronDown} />
+      </button>
+      <button type="button" className="transactions-toolbar-button">
+        <FontAwesomeIcon icon={faTableColumns} />
+        <span>Columns</span>
+      </button>
+    </div>
+  </div>
+);

--- a/client/src/features/transactions/TransactionsToolbar.tsx
+++ b/client/src/features/transactions/TransactionsToolbar.tsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown, faSquareCheck, faTableColumns } from '@fortawesome/free-solid-svg-icons';
 import { notImplementedToast } from '../../lib/toast';
+import { SortButton } from './SortButton';
 import './TransactionsToolbar.css';
 
 export const TransactionsToolbar = () => (
@@ -15,10 +16,7 @@ export const TransactionsToolbar = () => (
         <span>Edit multiple</span>
       </button>
       <span className="transactions-toolbar-divider" />
-      <button type="button" className="transactions-toolbar-button" onClick={notImplementedToast}>
-        <span>Sort</span>
-        <FontAwesomeIcon icon={faChevronDown} />
-      </button>
+      <SortButton />
       <button type="button" className="transactions-toolbar-button" onClick={notImplementedToast}>
         <FontAwesomeIcon icon={faTableColumns} />
         <span>Columns</span>

--- a/client/src/features/transactions/TransactionsToolbar.tsx
+++ b/client/src/features/transactions/TransactionsToolbar.tsx
@@ -1,24 +1,25 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown, faSquareCheck, faTableColumns } from '@fortawesome/free-solid-svg-icons';
+import { notImplementedToast } from '../../lib/toast';
 import './TransactionsToolbar.css';
 
 export const TransactionsToolbar = () => (
   <div className="transactions-toolbar">
-    <button type="button" className="transactions-toolbar-button">
+    <button type="button" className="transactions-toolbar-button" onClick={notImplementedToast}>
       <span>All transactions</span>
       <FontAwesomeIcon icon={faChevronDown} />
     </button>
     <div className="transactions-toolbar-actions">
-      <button type="button" className="transactions-toolbar-button">
+      <button type="button" className="transactions-toolbar-button" onClick={notImplementedToast}>
         <FontAwesomeIcon icon={faSquareCheck} />
         <span>Edit multiple</span>
       </button>
       <span className="transactions-toolbar-divider" />
-      <button type="button" className="transactions-toolbar-button">
+      <button type="button" className="transactions-toolbar-button" onClick={notImplementedToast}>
         <span>Sort</span>
         <FontAwesomeIcon icon={faChevronDown} />
       </button>
-      <button type="button" className="transactions-toolbar-button">
+      <button type="button" className="transactions-toolbar-button" onClick={notImplementedToast}>
         <FontAwesomeIcon icon={faTableColumns} />
         <span>Columns</span>
       </button>

--- a/client/src/features/transactions/format.ts
+++ b/client/src/features/transactions/format.ts
@@ -1,9 +1,11 @@
-/** Formats a signed number of dollars as `$1,234.56`. */
-export const formatAmount = (amount: number): string =>
-  `$${Math.abs(amount).toLocaleString('en-US', {
+/** Formats a signed number of dollars as `$1,234.56` (or `-$1,234.56` if negative). */
+export const formatAmount = (amount: number): string => {
+  const sign = amount < 0 ? '-' : '';
+  return `${sign}$${Math.abs(amount).toLocaleString('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })}`;
+};
 
 /** Formats an ISO `YYYY-MM-DD` date as `October 14, 2025`, without UTC-shifting the day. */
 export const formatDateHeading = (isoDate: string): string => {

--- a/client/src/features/transactions/format.ts
+++ b/client/src/features/transactions/format.ts
@@ -1,0 +1,16 @@
+/** Formats a signed number of dollars as `$1,234.56`. */
+export const formatAmount = (amount: number): string =>
+  `$${Math.abs(amount).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+
+/** Formats an ISO `YYYY-MM-DD` date as `October 14, 2025`, without UTC-shifting the day. */
+export const formatDateHeading = (isoDate: string): string => {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};

--- a/client/src/features/transactions/types.ts
+++ b/client/src/features/transactions/types.ts
@@ -1,3 +1,5 @@
+export type SortOrder = 'date' | 'inverse_date' | 'amount' | 'inverse_amount';
+
 export interface Transaction {
   id: number;
   date: string;

--- a/client/src/features/transactions/types.ts
+++ b/client/src/features/transactions/types.ts
@@ -1,0 +1,12 @@
+export interface Transaction {
+  id: number;
+  date: string;
+  merchant: string;
+  amount: string;
+  category_id: number;
+  category_name_en: string;
+  category_name_fr: string;
+  category_type: 'income' | 'expense' | 'transfer';
+  account: string;
+  created_at: string;
+}

--- a/client/src/features/transactions/use-transactions.ts
+++ b/client/src/features/transactions/use-transactions.ts
@@ -2,8 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '../../lib/api-client';
 import type { Transaction } from './types';
 
-export const useTransactions = () =>
+export const useTransactions = (search?: string) =>
   useQuery({
-    queryKey: ['transactions'],
-    queryFn: () => apiFetch<Transaction[]>('/transactions'),
+    queryKey: ['transactions', search ?? null],
+    queryFn: () =>
+      apiFetch<Transaction[]>(
+        search ? `/transactions?search=${encodeURIComponent(search)}` : '/transactions',
+      ),
   });

--- a/client/src/features/transactions/use-transactions.ts
+++ b/client/src/features/transactions/use-transactions.ts
@@ -1,12 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '../../lib/api-client';
-import type { Transaction } from './types';
+import type { SortOrder, Transaction } from './types';
 
-export const useTransactions = (search?: string) =>
+export const useTransactions = (search?: string, order?: SortOrder) =>
   useQuery({
-    queryKey: ['transactions', search ?? null],
-    queryFn: () =>
-      apiFetch<Transaction[]>(
-        search ? `/transactions?search=${encodeURIComponent(search)}` : '/transactions',
-      ),
+    queryKey: ['transactions', search ?? null, order ?? null],
+    queryFn: () => {
+      const params = new URLSearchParams();
+      if (search) params.set('search', search);
+      if (order) params.set('order', order);
+      const query = params.toString();
+      return apiFetch<Transaction[]>(`/transactions${query ? `?${query}` : ''}`);
+    },
   });

--- a/client/src/features/transactions/use-transactions.ts
+++ b/client/src/features/transactions/use-transactions.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../../lib/api-client';
+import type { Transaction } from './types';
+
+export const useTransactions = () =>
+  useQuery({
+    queryKey: ['transactions'],
+    queryFn: () => apiFetch<Transaction[]>('/transactions'),
+  });

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -40,25 +40,25 @@ body {
 body {
   background: var(--color-background);
   color: var(--color-white);
-  font: 400 18px/1.5 'Quicksand', sans-serif;
+  font: 400 18px/1.5 Quicksand, sans-serif;
 }
 
 h1 {
-  font: 700 44px/normal 'Nunito', sans-serif;
+  font: 700 44px/normal Nunito, sans-serif;
 }
 
 h2 {
-  font: 700 36px/normal 'Nunito', sans-serif;
+  font: 700 36px/normal Nunito, sans-serif;
 }
 
 h3 {
-  font: 700 28px/normal 'Nunito', sans-serif;
+  font: 700 28px/normal Nunito, sans-serif;
 }
 
 h4 {
-  font: 700 22px/normal 'Nunito', sans-serif;
+  font: 700 22px/normal Nunito, sans-serif;
 }
 
 .text-small {
-  font: 400 15px/1.5 'Quicksand', sans-serif;
+  font: 400 15px/1.5 Quicksand, sans-serif;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -30,8 +30,14 @@
 }
 
 /* Text styles */
+html,
 body {
+  height: 100%;
   margin: 0;
+  overflow: hidden;
+}
+
+body {
   background: var(--color-background);
   color: var(--color-white);
   font: 400 18px/1.5 'Quicksand', sans-serif;

--- a/client/src/lib/query-client.ts
+++ b/client/src/lib/query-client.ts
@@ -1,3 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
 
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+  defaultOptions: { queries: { staleTime: 60_000 } },
+});

--- a/client/src/lib/toast.ts
+++ b/client/src/lib/toast.ts
@@ -1,0 +1,3 @@
+import { toast } from 'sonner';
+
+export const notImplementedToast = () => toast.error('This feature is not available yet.');

--- a/client/src/lib/use-anchored-popover.ts
+++ b/client/src/lib/use-anchored-popover.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from 'react';
+
+type Position = { top: number; left: number };
+
+/**
+ * State + positioning for a button-triggered popover that's portaled to `document.body` (so it
+ * can't be clipped by a scrolling ancestor). Tracks the trigger's position on scroll/resize, and
+ * closes on outside click or Escape.
+ */
+export const useAnchoredPopover = <
+  TriggerElement extends HTMLElement = HTMLDivElement,
+  PopoverElement extends HTMLElement = HTMLDivElement,
+>() => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState<Position | null>(null);
+  const triggerRef = useRef<TriggerElement>(null);
+  const popoverRef = useRef<PopoverElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const updatePosition = () => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (rect) setPosition({ top: rect.bottom + 8, left: rect.left });
+    };
+    updatePosition();
+
+    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('resize', updatePosition);
+    return () => {
+      window.removeEventListener('scroll', updatePosition, true);
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target) || popoverRef.current?.contains(target)) return;
+      setIsOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  return { isOpen, setIsOpen, position, triggerRef, popoverRef };
+};

--- a/client/src/lib/use-anchored-popover.ts
+++ b/client/src/lib/use-anchored-popover.ts
@@ -1,11 +1,15 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 type Position = { top: number; left: number };
 
+/** Minimum gap kept between the popover and the viewport edge, matching the trigger-to-popover offset. */
+const VIEWPORT_MARGIN = 8;
+
 /**
  * State + positioning for a button-triggered popover that's portaled to `document.body` (so it
- * can't be clipped by a scrolling ancestor). Tracks the trigger's position on scroll/resize, and
- * closes on outside click or Escape.
+ * can't be clipped by a scrolling ancestor). Tracks the trigger's position on scroll/resize,
+ * clamps against the viewport once the popover's real size is measurable, and closes on outside
+ * click or Escape.
  */
 export const useAnchoredPopover = <
   TriggerElement extends HTMLElement = HTMLDivElement,
@@ -32,6 +36,22 @@ export const useAnchoredPopover = <
       window.removeEventListener('resize', updatePosition);
     };
   }, [isOpen]);
+
+  // Clamp against the viewport once the popover has mounted and its real size is measurable.
+  // Runs after every position change (including the ones above), converging in one extra pass:
+  // the clamped values it computes match `position` exactly on the next run, so it stops there.
+  useLayoutEffect(() => {
+    if (!position || !popoverRef.current) return;
+
+    const popoverRect = popoverRef.current.getBoundingClientRect();
+    const maxLeft = window.innerWidth - popoverRect.width - VIEWPORT_MARGIN;
+    const maxTop = window.innerHeight - popoverRect.height - VIEWPORT_MARGIN;
+
+    const left = Math.max(VIEWPORT_MARGIN, Math.min(position.left, maxLeft));
+    const top = Math.max(VIEWPORT_MARGIN, Math.min(position.top, maxTop));
+
+    if (left !== position.left || top !== position.top) setPosition({ left, top });
+  }, [position]);
 
   useEffect(() => {
     if (!isOpen) return;

--- a/client/src/routes/__root.css
+++ b/client/src/routes/__root.css
@@ -36,3 +36,8 @@
 .app-main::-webkit-scrollbar-thumb:hover {
   background-color: var(--color-light);
 }
+
+/* Sonner Toaster Message */
+[data-sonner-toast][data-type='error'] [data-icon] {
+  color: var(--color-error);
+}

--- a/client/src/routes/__root.css
+++ b/client/src/routes/__root.css
@@ -1,15 +1,38 @@
 .app-layout {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100vh;
 }
 
 .app-body {
   display: flex;
   flex: 1;
+  min-height: 0;
 }
 
 .app-main {
   flex: 1;
-  padding: var(--spacing-l);
+  min-width: 0;
+  padding: var(--spacing-l) var(--spacing-l) var(--spacing-l) 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-medium) transparent;
+}
+
+.app-main::-webkit-scrollbar {
+  width: 10px;
+}
+
+.app-main::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.app-main::-webkit-scrollbar-thumb {
+  background-color: var(--color-medium);
+  border-radius: var(--spacing-s);
+  border: 2px solid var(--color-background);
+}
+
+.app-main::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-light);
 }

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { Toaster } from 'sonner';
 import { TopMenu } from '../components/TopMenu';
 import { LeftMenu } from '../components/LeftMenu';
 import './__root.css';
@@ -14,6 +15,18 @@ const RootLayout = () => (
         <Outlet />
       </main>
     </div>
+    <Toaster
+      theme="dark"
+      position="bottom-right"
+      toastOptions={{
+        style: {
+          background: 'var(--color-dark)',
+          border: '1px solid var(--color-medium)',
+          color: 'var(--color-white)',
+          font: '400 15px/1.5 Quicksand, sans-serif',
+        },
+      }}
+    />
     <TanStackRouterDevtools />
     <ReactQueryDevtools />
   </div>

--- a/client/src/routes/transactions.tsx
+++ b/client/src/routes/transactions.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
 import {
-  faMagnifyingGlass,
   faCalendarDays,
   faFilter,
   faFileImport,
@@ -9,11 +8,14 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { TopMenuButton } from '../components/TopMenuButton';
 import { TransactionsList } from '../features/transactions/TransactionsList';
+import { SearchButton } from '../features/transactions/SearchButton';
 import { notImplementedToast } from '../lib/toast';
+
+type TransactionsSearch = { search?: string };
 
 const TransactionsTopMenuActions = () => (
   <>
-    <TopMenuButton icon={faMagnifyingGlass} label="Search" onClick={notImplementedToast} />
+    <SearchButton />
     <TopMenuButton icon={faCalendarDays} label="Date" onClick={notImplementedToast} />
     <TopMenuButton icon={faFilter} label="Filters" onClick={notImplementedToast} />
     <TopMenuButton icon={faFileImport} label="Import" onClick={notImplementedToast} />
@@ -26,5 +28,8 @@ const Transactions = () => <TransactionsList />;
 
 export const Route = createFileRoute('/transactions')({
   component: Transactions,
+  validateSearch: (search: Record<string, unknown>): TransactionsSearch => ({
+    search: typeof search.search === 'string' && search.search !== '' ? search.search : undefined,
+  }),
   staticData: { topMenuTitle: 'Transactions', topMenuActions: TransactionsTopMenuActions },
 });

--- a/client/src/routes/transactions.tsx
+++ b/client/src/routes/transactions.tsx
@@ -9,15 +9,16 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { TopMenuButton } from '../components/TopMenuButton';
 import { TransactionsList } from '../features/transactions/TransactionsList';
+import { notImplementedToast } from '../lib/toast';
 
 const TransactionsTopMenuActions = () => (
   <>
-    <TopMenuButton icon={faMagnifyingGlass} label="Search" />
-    <TopMenuButton icon={faCalendarDays} label="Date" />
-    <TopMenuButton icon={faFilter} label="Filters" />
-    <TopMenuButton icon={faFileImport} label="Import" />
-    <TopMenuButton icon={faDownload} label="Download" />
-    <TopMenuButton icon={faPlus} label="Add" variant="primary" />
+    <TopMenuButton icon={faMagnifyingGlass} label="Search" onClick={notImplementedToast} />
+    <TopMenuButton icon={faCalendarDays} label="Date" onClick={notImplementedToast} />
+    <TopMenuButton icon={faFilter} label="Filters" onClick={notImplementedToast} />
+    <TopMenuButton icon={faFileImport} label="Import" onClick={notImplementedToast} />
+    <TopMenuButton icon={faDownload} label="Download" onClick={notImplementedToast} />
+    <TopMenuButton icon={faPlus} label="Add" variant="primary" onClick={notImplementedToast} />
   </>
 );
 

--- a/client/src/routes/transactions.tsx
+++ b/client/src/routes/transactions.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, getRouteApi } from '@tanstack/react-router';
 import {
   faCalendarDays,
   faFilter,
@@ -10,11 +10,35 @@ import { TopMenuButton } from '../components/TopMenuButton';
 import { TransactionsList } from '../features/transactions/TransactionsList';
 import { SearchButton } from '../features/transactions/SearchButton';
 import { notImplementedToast } from '../lib/toast';
+import type { SortOrder } from '../features/transactions/types';
+import '../components/TopMenu.css';
 
-type TransactionsSearch = { search?: string };
+type TransactionsSearch = { search?: string; order?: SortOrder };
+
+const SORT_ORDERS: SortOrder[] = ['date', 'inverse_date', 'amount', 'inverse_amount'];
+
+const routeApi = getRouteApi('/transactions');
+
+const ClearAllButton = () => {
+  const { search, order } = routeApi.useSearch();
+  const navigate = routeApi.useNavigate();
+
+  if (!search && !order) return null;
+
+  return (
+    <button
+      type="button"
+      className="top-menu-clear-all"
+      onClick={() => navigate({ search: {}, replace: true })}
+    >
+      Clear
+    </button>
+  );
+};
 
 const TransactionsTopMenuActions = () => (
   <>
+    <ClearAllButton />
     <SearchButton />
     <TopMenuButton icon={faCalendarDays} label="Date" onClick={notImplementedToast} />
     <TopMenuButton icon={faFilter} label="Filters" onClick={notImplementedToast} />
@@ -30,6 +54,7 @@ export const Route = createFileRoute('/transactions')({
   component: Transactions,
   validateSearch: (search: Record<string, unknown>): TransactionsSearch => ({
     search: typeof search.search === 'string' && search.search !== '' ? search.search : undefined,
+    order: SORT_ORDERS.includes(search.order as SortOrder) ? (search.order as SortOrder) : undefined,
   }),
   staticData: { topMenuTitle: 'Transactions', topMenuActions: TransactionsTopMenuActions },
 });

--- a/client/src/routes/transactions.tsx
+++ b/client/src/routes/transactions.tsx
@@ -8,6 +8,7 @@ import {
   faPlus,
 } from '@fortawesome/free-solid-svg-icons';
 import { TopMenuButton } from '../components/TopMenuButton';
+import { TransactionsList } from '../features/transactions/TransactionsList';
 
 const TransactionsTopMenuActions = () => (
   <>
@@ -15,12 +16,12 @@ const TransactionsTopMenuActions = () => (
     <TopMenuButton icon={faCalendarDays} label="Date" />
     <TopMenuButton icon={faFilter} label="Filters" />
     <TopMenuButton icon={faFileImport} label="Import" />
-    <TopMenuButton icon={faDownload} label="Export" />
+    <TopMenuButton icon={faDownload} label="Download" />
     <TopMenuButton icon={faPlus} label="Add" variant="primary" />
   </>
 );
 
-const Transactions = () => null;
+const Transactions = () => <TransactionsList />;
 
 export const Route = createFileRoute('/transactions')({
   component: Transactions,

--- a/server/src/features/transactions/handlers.rs
+++ b/server/src/features/transactions/handlers.rs
@@ -44,7 +44,8 @@ async fn create_transaction(
     }
 }
 
-/// `GET /transactions` — list transactions, optionally filtered by `date` and/or `merchant`.
+/// `GET /transactions` — list transactions, optionally filtered by `date`, `merchant`, and/or a
+/// free-text `search` matched against merchant, category, and amount.
 async fn list_transactions(
     filter: web::Query<TransactionFilter>,
     pool: web::Data<PgPool>,

--- a/server/src/features/transactions/handlers.rs
+++ b/server/src/features/transactions/handlers.rs
@@ -45,7 +45,8 @@ async fn create_transaction(
 }
 
 /// `GET /transactions` — list transactions, optionally filtered by `date`, `merchant`, and/or a
-/// free-text `search` matched against merchant, category, and amount.
+/// free-text `search` matched against merchant, category, and amount. Accepts `order` (`date`,
+/// `inverse_date`, `amount`, `inverse_amount`) to control sort order.
 async fn list_transactions(
     filter: web::Query<TransactionFilter>,
     pool: web::Data<PgPool>,

--- a/server/src/features/transactions/model.rs
+++ b/server/src/features/transactions/model.rs
@@ -33,6 +33,8 @@ pub struct NewTransaction {
 pub struct TransactionFilter {
     pub date: Option<NaiveDate>,
     pub merchant: Option<String>,
+    /// Case-insensitive substring match against merchant, category name, or amount.
+    pub search: Option<String>,
 }
 
 /// Body for `PATCH /transactions/{id}`. `None` fields are left unchanged.

--- a/server/src/features/transactions/model.rs
+++ b/server/src/features/transactions/model.rs
@@ -35,6 +35,22 @@ pub struct TransactionFilter {
     pub merchant: Option<String>,
     /// Case-insensitive substring match against merchant, category name, or amount.
     pub search: Option<String>,
+    /// Sort order. Defaults to `Date` (most recent first) when absent.
+    pub order: Option<SortOrder>,
+}
+
+/// Sort order for `GET /transactions`.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SortOrder {
+    /// Most recent date first (default).
+    Date,
+    /// Oldest date first.
+    InverseDate,
+    /// Highest amount first.
+    Amount,
+    /// Lowest amount first.
+    InverseAmount,
 }
 
 /// Body for `PATCH /transactions/{id}`. `None` fields are left unchanged.

--- a/server/src/features/transactions/repository.rs
+++ b/server/src/features/transactions/repository.rs
@@ -9,6 +9,13 @@ const SELECT_COLUMNS: &str = "
 
 const FROM_JOIN: &str = "FROM transactions t JOIN categories c ON c.id = t.category_id";
 
+/// Escapes `\`, `%`, and `_` so a search term is matched as a literal substring by `ILIKE ...
+/// ESCAPE E'\\'`, rather than having `%`/`_` act as wildcards. Backslashes must be escaped first,
+/// or the backslashes introduced for `%`/`_` would themselves get re-escaped.
+fn escape_like(term: &str) -> String {
+    term.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+}
+
 /// Inserts a new transaction and returns the created row, joined with its category.
 pub async fn create(
     pool: &PgPool,
@@ -47,21 +54,23 @@ pub async fn list(
         Some(SortOrder::InverseAmount) => "t.amount ASC, t.id DESC",
     };
 
+    let escaped_search = filter.search.as_deref().map(escape_like);
+
     sqlx::query_as::<_, Transaction>(&format!(
         "SELECT {SELECT_COLUMNS} {FROM_JOIN}
          WHERE ($1::date IS NULL OR t.date = $1)
            AND ($2::text IS NULL OR t.merchant ILIKE '%' || $2 || '%')
            AND ($3::text IS NULL OR (
-                 t.merchant ILIKE '%' || $3 || '%'
-              OR c.name_en ILIKE '%' || $3 || '%'
-              OR c.name_fr ILIKE '%' || $3 || '%'
-              OR t.amount::text ILIKE '%' || $3 || '%'
+                 t.merchant ILIKE '%' || $3 || '%' ESCAPE E'\\\\'
+              OR c.name_en ILIKE '%' || $3 || '%' ESCAPE E'\\\\'
+              OR c.name_fr ILIKE '%' || $3 || '%' ESCAPE E'\\\\'
+              OR t.amount::text ILIKE '%' || $3 || '%' ESCAPE E'\\\\'
            ))
          ORDER BY {order_by}"
     ))
     .bind(filter.date)
     .bind(&filter.merchant)
-    .bind(&filter.search)
+    .bind(&escaped_search)
     .fetch_all(pool)
     .await
 }

--- a/server/src/features/transactions/repository.rs
+++ b/server/src/features/transactions/repository.rs
@@ -32,8 +32,9 @@ pub async fn create(
     .await
 }
 
-/// Lists transactions, optionally narrowed by an exact date match and/or a
-/// case-insensitive merchant substring match. Most recent first.
+/// Lists transactions, optionally narrowed by an exact date match, a case-insensitive merchant
+/// substring match, and/or a free-text search across merchant, category name, and amount. Most
+/// recent first.
 pub async fn list(
     pool: &PgPool,
     filter: &TransactionFilter,
@@ -42,10 +43,17 @@ pub async fn list(
         "SELECT {SELECT_COLUMNS} {FROM_JOIN}
          WHERE ($1::date IS NULL OR t.date = $1)
            AND ($2::text IS NULL OR t.merchant ILIKE '%' || $2 || '%')
+           AND ($3::text IS NULL OR (
+                 t.merchant ILIKE '%' || $3 || '%'
+              OR c.name_en ILIKE '%' || $3 || '%'
+              OR c.name_fr ILIKE '%' || $3 || '%'
+              OR t.amount::text ILIKE '%' || $3 || '%'
+           ))
          ORDER BY t.date DESC, t.id DESC"
     ))
     .bind(filter.date)
     .bind(&filter.merchant)
+    .bind(&filter.search)
     .fetch_all(pool)
     .await
 }

--- a/server/src/features/transactions/repository.rs
+++ b/server/src/features/transactions/repository.rs
@@ -13,7 +13,9 @@ const FROM_JOIN: &str = "FROM transactions t JOIN categories c ON c.id = t.categ
 /// ESCAPE E'\\'`, rather than having `%`/`_` act as wildcards. Backslashes must be escaped first,
 /// or the backslashes introduced for `%`/`_` would themselves get re-escaped.
 fn escape_like(term: &str) -> String {
-    term.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+    term.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
 }
 
 /// Inserts a new transaction and returns the created row, joined with its category.

--- a/server/src/features/transactions/repository.rs
+++ b/server/src/features/transactions/repository.rs
@@ -1,6 +1,6 @@
 use sqlx::PgPool;
 
-use super::model::{NewTransaction, Transaction, TransactionFilter, TransactionPatch};
+use super::model::{NewTransaction, SortOrder, Transaction, TransactionFilter, TransactionPatch};
 
 const SELECT_COLUMNS: &str = "
     t.id, t.date, t.merchant, t.amount, t.category_id,
@@ -33,12 +33,20 @@ pub async fn create(
 }
 
 /// Lists transactions, optionally narrowed by an exact date match, a case-insensitive merchant
-/// substring match, and/or a free-text search across merchant, category name, and amount. Most
-/// recent first.
+/// substring match, and/or a free-text search across merchant, category name, and amount. Sorted
+/// per `filter.order` (most recent first by default).
 pub async fn list(
     pool: &PgPool,
     filter: &TransactionFilter,
 ) -> Result<Vec<Transaction>, sqlx::Error> {
+    // `id DESC` is a stable tie-breaker for rows sharing a date/amount; never built from user input.
+    let order_by = match filter.order {
+        None | Some(SortOrder::Date) => "t.date DESC, t.id DESC",
+        Some(SortOrder::InverseDate) => "t.date ASC, t.id DESC",
+        Some(SortOrder::Amount) => "t.amount DESC, t.id DESC",
+        Some(SortOrder::InverseAmount) => "t.amount ASC, t.id DESC",
+    };
+
     sqlx::query_as::<_, Transaction>(&format!(
         "SELECT {SELECT_COLUMNS} {FROM_JOIN}
          WHERE ($1::date IS NULL OR t.date = $1)
@@ -49,7 +57,7 @@ pub async fn list(
               OR c.name_fr ILIKE '%' || $3 || '%'
               OR t.amount::text ILIKE '%' || $3 || '%'
            ))
-         ORDER BY t.date DESC, t.id DESC"
+         ORDER BY {order_by}"
     ))
     .bind(filter.date)
     .bind(&filter.merchant)

--- a/server/src/features/transactions/tests.rs
+++ b/server/src/features/transactions/tests.rs
@@ -232,6 +232,61 @@ async fn list_transactions_filters_by_search_is_case_insensitive(pool: PgPool) {
 }
 
 #[sqlx::test]
+async fn list_transactions_filters_by_search_treats_percent_literally(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "50% OFF STORE", "12.34").await;
+    create_via_api(&app, "2024-01-16", "50X OFF STORE", "56.78").await;
+
+    // "50% OFF" URL-encoded: %25 is a literal '%', %20 is a space.
+    let req = test::TestRequest::get()
+        .uri("/transactions?search=50%25%20OFF")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["merchant"], "50% OFF STORE");
+}
+
+#[sqlx::test]
+async fn list_transactions_filters_by_search_treats_underscore_literally(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "ITEM_CODE 123", "12.34").await;
+    create_via_api(&app, "2024-01-16", "ITEMXCODE 123", "56.78").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?search=ITEM_CODE")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["merchant"], "ITEM_CODE 123");
+}
+
+#[sqlx::test]
+async fn list_transactions_filters_by_search_treats_backslash_literally(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", r"PATH\TO STORE", "12.34").await;
+
+    // "PATH\TO" URL-encoded: %5C is a literal backslash.
+    let req = test::TestRequest::get()
+        .uri("/transactions?search=PATH%5CTO")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["merchant"], r"PATH\TO STORE");
+}
+
+#[sqlx::test]
 async fn list_transactions_filters_by_search_returns_empty_when_no_matches(pool: PgPool) {
     let app = test::init_service(app_with(pool)).await;
     create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;

--- a/server/src/features/transactions/tests.rs
+++ b/server/src/features/transactions/tests.rs
@@ -124,6 +124,129 @@ async fn list_transactions_filters_by_date_and_merchant_combined(pool: PgPool) {
 }
 
 #[sqlx::test]
+async fn list_transactions_filters_by_search_matches_merchant(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+    create_via_api(&app, "2024-01-16", "IGA SUPERMARKT", "56.78").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?search=starb")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["merchant"], "STARBUCKS");
+}
+
+#[sqlx::test]
+async fn list_transactions_filters_by_search_matches_category_name(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await; // category_id 1 = Other/Autre
+
+    let req = test::TestRequest::post()
+        .uri("/transactions")
+        .set_json(serde_json::json!({
+            "date": "2024-01-16",
+            "merchant": "SCHOOL SUPPLIES",
+            "amount": "40.00",
+            "category_id": 7,
+            "account": "User 1",
+        }))
+        .to_request();
+    test::call_service(&app, req).await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?search=educ")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["merchant"], "SCHOOL SUPPLIES");
+    assert_eq!(rows[0]["category_name_en"], "Education");
+}
+
+#[sqlx::test]
+async fn list_transactions_filters_by_search_matches_french_category_name(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    let req = test::TestRequest::post()
+        .uri("/transactions")
+        .set_json(serde_json::json!({
+            "date": "2024-01-16",
+            "merchant": "SCHOOL SUPPLIES",
+            "amount": "40.00",
+            "category_id": 7,
+            "account": "User 1",
+        }))
+        .to_request();
+    test::call_service(&app, req).await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?search=%C3%A9duc")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["category_name_fr"], "Éducation");
+}
+
+#[sqlx::test]
+async fn list_transactions_filters_by_search_matches_amount(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+    create_via_api(&app, "2024-01-16", "IGA", "56.78").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?search=12.34")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["merchant"], "STARBUCKS");
+}
+
+#[sqlx::test]
+async fn list_transactions_filters_by_search_is_case_insensitive(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?search=STARbucks")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body.as_array().unwrap().len(), 1);
+}
+
+#[sqlx::test]
+async fn list_transactions_filters_by_search_returns_empty_when_no_matches(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?search=nonexistent")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body.as_array().unwrap().len(), 0);
+}
+
+#[sqlx::test]
 async fn list_transactions_returns_empty_array_when_no_matches(pool: PgPool) {
     let app = test::init_service(app_with(pool)).await;
     create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;

--- a/server/src/features/transactions/tests.rs
+++ b/server/src/features/transactions/tests.rs
@@ -278,6 +278,94 @@ async fn list_transactions_orders_by_date_desc(pool: PgPool) {
     assert_eq!(dates, vec!["2024-01-17", "2024-01-16", "2024-01-15"]);
 }
 
+#[sqlx::test]
+async fn list_transactions_orders_by_date_explicit(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+    create_via_api(&app, "2024-01-17", "SHELL", "40.00").await;
+    create_via_api(&app, "2024-01-16", "IGA", "56.78").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?order=date")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    let dates: Vec<&str> = rows.iter().map(|r| r["date"].as_str().unwrap()).collect();
+    assert_eq!(dates, vec!["2024-01-17", "2024-01-16", "2024-01-15"]);
+}
+
+#[sqlx::test]
+async fn list_transactions_orders_by_inverse_date(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+    create_via_api(&app, "2024-01-17", "SHELL", "40.00").await;
+    create_via_api(&app, "2024-01-16", "IGA", "56.78").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?order=inverse_date")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    let dates: Vec<&str> = rows.iter().map(|r| r["date"].as_str().unwrap()).collect();
+    assert_eq!(dates, vec!["2024-01-15", "2024-01-16", "2024-01-17"]);
+}
+
+#[sqlx::test]
+async fn list_transactions_orders_by_amount_desc(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+    create_via_api(&app, "2024-01-17", "SHELL", "40.00").await;
+    create_via_api(&app, "2024-01-16", "IGA", "56.78").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?order=amount")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    let amounts: Vec<&str> = rows.iter().map(|r| r["amount"].as_str().unwrap()).collect();
+    assert_eq!(amounts, vec!["56.78", "40.00", "12.34"]);
+}
+
+#[sqlx::test]
+async fn list_transactions_orders_by_inverse_amount(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+    create_via_api(&app, "2024-01-17", "SHELL", "40.00").await;
+    create_via_api(&app, "2024-01-16", "IGA", "56.78").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?order=inverse_amount")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let rows = body.as_array().unwrap();
+    let amounts: Vec<&str> = rows.iter().map(|r| r["amount"].as_str().unwrap()).collect();
+    assert_eq!(amounts, vec!["12.34", "40.00", "56.78"]);
+}
+
+#[sqlx::test]
+async fn list_transactions_rejects_invalid_order(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions?order=nonsense")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 400);
+}
+
 // --- GET /transactions/{id} ---
 
 #[sqlx::test]


### PR DESCRIPTION
First part of #20: renders real transactions from the API grouped by date with a daily total, a merchant/category/account/amount table inside a single rounded card, and the All transactions/Edit multiple/Sort/Columns toolbar (no action logic yet). Also fixes the app layout so only the content area scrolls, with a themed scrollbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Transactions page with grouped daily totals, transaction rows, and loading/error/empty states.
  * Introduced a transactions toolbar with search and sort controls, powered by URL parameters (including clear behavior).
  * Added consistent amount/date formatting and signed credit/income display.
* **Usability Improvements**
  * Improved scrolling behavior and cross-browser scrollbar styling for menus and the main area.
  * Refined row layout (hover feedback, truncation) and keyboard focus styling for toolbar popovers.
* **Other**
  * Renamed the top-menu action from “Export” to “Download”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->