### PR TITLE
Feature: Add Download action to Transactions page

### DIFF
--- a/client/src/components/TopMenuButton.tsx
+++ b/client/src/components/TopMenuButton.tsx
@@ -1,4 +1,6 @@
+import type { AriaAttributes } from 'react';
 import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { forwardRef } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import './TopMenuButton.css';
 
@@ -7,15 +9,38 @@ type TopMenuButtonProps = {
   label: string;
   variant?: 'default' | 'primary';
   onClick?: () => void;
+  'aria-haspopup'?: AriaAttributes['aria-haspopup'];
+  'aria-expanded'?: boolean;
 };
 
-export const TopMenuButton = ({ icon, label, variant = 'default', onClick }: TopMenuButtonProps) => (
-  <button
-    type="button"
-    className={variant === 'primary' ? 'top-menu-button top-menu-button--primary' : 'top-menu-button'}
-    onClick={onClick}
-  >
-    <FontAwesomeIcon icon={icon} />
-    <span>{label}</span>
-  </button>
+export const TopMenuButton = forwardRef<HTMLButtonElement, TopMenuButtonProps>(
+  (
+    {
+      icon,
+      label,
+      variant = 'default',
+      onClick,
+      'aria-haspopup': ariaHasPopup,
+      'aria-expanded': ariaExpanded,
+    },
+    ref,
+  ) => (
+    <button
+      ref={ref}
+      type="button"
+      className={
+        variant === 'primary'
+          ? 'top-menu-button top-menu-button--primary'
+          : 'top-menu-button'
+      }
+      onClick={onClick}
+      aria-haspopup={ariaHasPopup}
+      aria-expanded={ariaExpanded}
+    >
+      <FontAwesomeIcon icon={icon} />
+      <span>{label}</span>
+    </button>
+  ),
 );
+
+TopMenuButton.displayName = 'TopMenuButton';

--- a/client/src/features/transactions/DownloadButton.css
+++ b/client/src/features/transactions/DownloadButton.css
@@ -1,0 +1,29 @@
+.download-button-trigger {
+  position: relative;
+  display: inline-flex;
+}
+
+.download-popover {
+  width: 220px;
+  padding: var(--spacing-xs);
+  gap: 2px;
+}
+
+.download-popover-option {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-xs) var(--spacing-s);
+  border: none;
+  border-radius: var(--spacing-xs);
+  background: none;
+  color: var(--color-white);
+  font: 400 15px/1.5 Quicksand, sans-serif;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.download-popover-option:hover,
+.download-popover-option:focus-visible {
+  background: var(--color-medium);
+}

--- a/client/src/features/transactions/DownloadButton.tsx
+++ b/client/src/features/transactions/DownloadButton.tsx
@@ -1,0 +1,63 @@
+import { createPortal } from 'react-dom';
+import { getRouteApi } from '@tanstack/react-router';
+import { faDownload } from '@fortawesome/free-solid-svg-icons';
+import { TopMenuButton } from '../../components/TopMenuButton';
+import { useAnchoredPopover } from '../../lib/use-anchored-popover';
+import { downloadFailedToast } from '../../lib/toast';
+import { downloadTransactions } from './download';
+import type { DownloadFormat } from './download';
+import '../../components/Popover.css';
+import './DownloadButton.css';
+
+const routeApi = getRouteApi('/transactions');
+
+const DOWNLOAD_OPTIONS: { value: DownloadFormat; label: string }[] = [
+  { value: 'csv', label: 'Download as CSV' },
+  { value: 'xlsx', label: 'Download as Excel' },
+];
+
+export const DownloadButton = () => {
+  const { search, order } = routeApi.useSearch();
+  const { isOpen, setIsOpen, position, triggerRef, popoverRef } =
+    useAnchoredPopover();
+
+  const handleSelect = async (format: DownloadFormat) => {
+    setIsOpen(false);
+    try {
+      await downloadTransactions(format, search, order);
+    } catch {
+      downloadFailedToast();
+    }
+  };
+
+  return (
+    <div className="download-button-trigger" ref={triggerRef}>
+      <TopMenuButton
+        icon={faDownload}
+        label="Download"
+        onClick={() => setIsOpen((open) => !open)}
+      />
+      {isOpen &&
+        position &&
+        createPortal(
+          <div
+            className="anchored-popover download-popover"
+            ref={popoverRef}
+            style={{ top: position.top, left: position.left }}
+          >
+            {DOWNLOAD_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className="download-popover-option"
+                onClick={() => handleSelect(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+};

--- a/client/src/features/transactions/DownloadButton.tsx
+++ b/client/src/features/transactions/DownloadButton.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { getRouteApi } from '@tanstack/react-router';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
@@ -19,7 +20,25 @@ const DOWNLOAD_OPTIONS: { value: DownloadFormat; label: string }[] = [
 export const DownloadButton = () => {
   const { search, order } = routeApi.useSearch();
   const { isOpen, setIsOpen, position, triggerRef, popoverRef } =
-    useAnchoredPopover();
+    useAnchoredPopover<HTMLButtonElement>();
+  const firstOptionRef = useRef<HTMLButtonElement>(null);
+  const wasOpenRef = useRef(false);
+
+  // Return focus to the trigger once the popover actually closes (selection, outside click, or
+  // Escape), but not on first mount.
+  useEffect(() => {
+    if (isOpen) {
+      wasOpenRef.current = true;
+    } else if (wasOpenRef.current) {
+      wasOpenRef.current = false;
+      triggerRef.current?.focus();
+    }
+  }, [isOpen, triggerRef]);
+
+  // Move focus into the popover once it's mounted and positioned.
+  useEffect(() => {
+    if (isOpen && position) firstOptionRef.current?.focus();
+  }, [isOpen, position]);
 
   const handleSelect = async (format: DownloadFormat) => {
     setIsOpen(false);
@@ -31,10 +50,13 @@ export const DownloadButton = () => {
   };
 
   return (
-    <div className="download-button-trigger" ref={triggerRef}>
+    <div className="download-button-trigger">
       <TopMenuButton
+        ref={triggerRef}
         icon={faDownload}
         label="Download"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
         onClick={() => setIsOpen((open) => !open)}
       />
       {isOpen &&
@@ -45,9 +67,10 @@ export const DownloadButton = () => {
             ref={popoverRef}
             style={{ top: position.top, left: position.left }}
           >
-            {DOWNLOAD_OPTIONS.map((option) => (
+            {DOWNLOAD_OPTIONS.map((option, index) => (
               <button
                 key={option.value}
+                ref={index === 0 ? firstOptionRef : undefined}
                 type="button"
                 className="download-popover-option"
                 onClick={() => handleSelect(option.value)}

--- a/client/src/features/transactions/download.ts
+++ b/client/src/features/transactions/download.ts
@@ -1,0 +1,21 @@
+import { apiFetchFile } from '../../lib/api-client';
+import { downloadBlob } from '../../lib/download-file';
+import type { SortOrder } from './types';
+
+export type DownloadFormat = 'csv' | 'xlsx';
+
+/** Downloads the same (filtered/sorted) transactions shown on the page, as a CSV or Excel file. */
+export const downloadTransactions = async (
+  format: DownloadFormat,
+  search?: string,
+  order?: SortOrder,
+) => {
+  const params = new URLSearchParams({ format });
+  if (search) params.set('search', search);
+  if (order) params.set('order', order);
+
+  const { blob, filename } = await apiFetchFile(
+    `/transactions/download?${params.toString()}`,
+  );
+  downloadBlob(blob, filename ?? `transactions.${format}`);
+};

--- a/client/src/lib/api-client.ts
+++ b/client/src/lib/api-client.ts
@@ -17,3 +17,22 @@ export const apiFetch = async <T>(
 
   return response.json() as Promise<T>;
 };
+
+/** Extracts the `filename` param from a `Content-Disposition: attachment; filename="..."` header. */
+const parseFilename = (contentDisposition: string | null): string | undefined =>
+  contentDisposition?.match(/filename="([^"]+)"/)?.[1];
+
+export const apiFetchFile = async (
+  path: string,
+): Promise<{ blob: Blob; filename?: string }> => {
+  const response = await fetch(`${API_BASE_URL}${path}`);
+
+  if (!response.ok) {
+    throw new Error(`GET ${path} failed: ${response.status}`);
+  }
+
+  return {
+    blob: await response.blob(),
+    filename: parseFilename(response.headers.get('Content-Disposition')),
+  };
+};

--- a/client/src/lib/download-file.ts
+++ b/client/src/lib/download-file.ts
@@ -1,0 +1,11 @@
+/** Triggers a browser download of `blob` named `filename`, without navigating away from the page. */
+export const downloadBlob = (blob: Blob, filename: string) => {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};

--- a/client/src/lib/toast.ts
+++ b/client/src/lib/toast.ts
@@ -1,3 +1,7 @@
 import { toast } from 'sonner';
 
-export const notImplementedToast = () => toast.error('This feature is not available yet.');
+export const notImplementedToast = () =>
+  toast.error('This feature is not available yet.');
+
+export const downloadFailedToast = () =>
+  toast.error('Failed to download transactions.');

--- a/client/src/routes/transactions.tsx
+++ b/client/src/routes/transactions.tsx
@@ -3,19 +3,24 @@ import {
   faCalendarDays,
   faFilter,
   faFileImport,
-  faDownload,
   faPlus,
 } from '@fortawesome/free-solid-svg-icons';
 import { TopMenuButton } from '../components/TopMenuButton';
 import { TransactionsList } from '../features/transactions/TransactionsList';
 import { SearchButton } from '../features/transactions/SearchButton';
+import { DownloadButton } from '../features/transactions/DownloadButton';
 import { notImplementedToast } from '../lib/toast';
 import type { SortOrder } from '../features/transactions/types';
 import '../components/TopMenu.css';
 
 type TransactionsSearch = { search?: string; order?: SortOrder };
 
-const SORT_ORDERS: SortOrder[] = ['date', 'inverse_date', 'amount', 'inverse_amount'];
+const SORT_ORDERS: SortOrder[] = [
+  'date',
+  'inverse_date',
+  'amount',
+  'inverse_amount',
+];
 
 const routeApi = getRouteApi('/transactions');
 
@@ -40,11 +45,28 @@ const TransactionsTopMenuActions = () => (
   <>
     <ClearAllButton />
     <SearchButton />
-    <TopMenuButton icon={faCalendarDays} label="Date" onClick={notImplementedToast} />
-    <TopMenuButton icon={faFilter} label="Filters" onClick={notImplementedToast} />
-    <TopMenuButton icon={faFileImport} label="Import" onClick={notImplementedToast} />
-    <TopMenuButton icon={faDownload} label="Download" onClick={notImplementedToast} />
-    <TopMenuButton icon={faPlus} label="Add" variant="primary" onClick={notImplementedToast} />
+    <TopMenuButton
+      icon={faCalendarDays}
+      label="Date"
+      onClick={notImplementedToast}
+    />
+    <TopMenuButton
+      icon={faFilter}
+      label="Filters"
+      onClick={notImplementedToast}
+    />
+    <TopMenuButton
+      icon={faFileImport}
+      label="Import"
+      onClick={notImplementedToast}
+    />
+    <DownloadButton />
+    <TopMenuButton
+      icon={faPlus}
+      label="Add"
+      variant="primary"
+      onClick={notImplementedToast}
+    />
   </>
 );
 
@@ -53,8 +75,16 @@ const Transactions = () => <TransactionsList />;
 export const Route = createFileRoute('/transactions')({
   component: Transactions,
   validateSearch: (search: Record<string, unknown>): TransactionsSearch => ({
-    search: typeof search.search === 'string' && search.search !== '' ? search.search : undefined,
-    order: SORT_ORDERS.includes(search.order as SortOrder) ? (search.order as SortOrder) : undefined,
+    search:
+      typeof search.search === 'string' && search.search !== ''
+        ? search.search
+        : undefined,
+    order: SORT_ORDERS.includes(search.order as SortOrder)
+      ? (search.order as SortOrder)
+      : undefined,
   }),
-  staticData: { topMenuTitle: 'Transactions', topMenuActions: TransactionsTopMenuActions },
+  staticData: {
+    topMenuTitle: 'Transactions',
+    topMenuActions: TransactionsTopMenuActions,
+  },
 });

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -607,6 +607,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +792,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1857,6 +1879,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_xlsxwriter"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1746025420e17b5d62528b930e550e016e857038794d74e169018126ef3d14"
+dependencies = [
+ "chrono",
+ "rust_decimal",
+ "zip",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,11 +2018,13 @@ dependencies = [
  "actix-http",
  "actix-web",
  "chrono",
+ "csv",
  "dotenvy",
  "env_logger",
  "fluent",
  "log",
  "rust_decimal",
+ "rust_xlsxwriter",
  "serde",
  "serde_json",
  "sqlx",
@@ -2576,6 +2611,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,10 +3144,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2021"
 actix-cors = "0.7.1"
 actix-web = "4.13.0"
 chrono = { version = "0.4", features = ["serde"] }
+csv = "1"
 dotenvy = "0.15"
 env_logger = "0.11.8"
 fluent = "0.16"
 log = "0.4.28"
 rust_decimal = { version = "1", features = ["serde-with-str"] }
+rust_xlsxwriter = { version = "0.96", features = ["rust_decimal", "chrono"] }
 serde = { version = "1.0.228", features = ["derive"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "migrate", "chrono", "rust_decimal"] }
 unic-langid = "0.9"

--- a/server/src/features/transactions/download.rs
+++ b/server/src/features/transactions/download.rs
@@ -1,0 +1,87 @@
+//! Renders transactions as CSV or Excel (`.xlsx`) bytes for `GET /transactions/download`.
+
+use rust_xlsxwriter::{Workbook, XlsxError};
+
+use super::model::{SortOrder, Transaction, TransactionFilter};
+
+const HEADERS: [&str; 4] = ["Date", "Merchant", "Category", "Amount"];
+
+/// Builds a filename like `transactions_starbucks_highest-amount.csv` from the filters that were
+/// actually applied, so the downloaded file's name reflects what's inside it.
+pub fn filename(filter: &TransactionFilter, extension: &str) -> String {
+    let mut parts = vec!["transactions".to_string()];
+
+    if let Some(date) = filter.date {
+        parts.push(date.to_string());
+    }
+    if let Some(merchant) = &filter.merchant {
+        parts.push(slugify(merchant));
+    }
+    if let Some(search) = &filter.search {
+        parts.push(slugify(search));
+    }
+    match filter.order {
+        Some(SortOrder::InverseDate) => parts.push("oldest-first".to_string()),
+        Some(SortOrder::Amount) => parts.push("highest-amount".to_string()),
+        Some(SortOrder::InverseAmount) => parts.push("lowest-amount".to_string()),
+        Some(SortOrder::Date) | None => {}
+    }
+
+    format!("{}.{extension}", parts.join("_"))
+}
+
+/// Lowercases `text` and replaces runs of non-alphanumeric characters with a single `-`, so it's
+/// safe to embed in a filename. Truncated to keep filenames reasonable for long search terms.
+fn slugify(text: &str) -> String {
+    let dashed: String = text
+        .trim()
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+
+    dashed
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+        .chars()
+        .take(40)
+        .collect()
+}
+
+/// Renders transactions as CSV bytes, with a header row.
+pub fn to_csv(transactions: &[Transaction]) -> Result<Vec<u8>, csv::Error> {
+    let mut writer = csv::Writer::from_writer(Vec::new());
+
+    writer.write_record(HEADERS)?;
+    for transaction in transactions {
+        writer.write_record([
+            transaction.date.to_string(),
+            transaction.merchant.clone(),
+            transaction.category_name_en.clone(),
+            transaction.amount.to_string(),
+        ])?;
+    }
+
+    writer.into_inner().map_err(|e| e.into_error().into())
+}
+
+/// Renders transactions as `.xlsx` bytes, with a header row.
+pub fn to_xlsx(transactions: &[Transaction]) -> Result<Vec<u8>, XlsxError> {
+    let mut workbook = Workbook::new();
+    let worksheet = workbook.add_worksheet();
+
+    for (col, header) in HEADERS.iter().enumerate() {
+        worksheet.write(0, col as u16, *header)?;
+    }
+    for (index, transaction) in transactions.iter().enumerate() {
+        let row = index as u32 + 1;
+        worksheet.write(row, 0, transaction.date.to_string())?;
+        worksheet.write(row, 1, &transaction.merchant)?;
+        worksheet.write(row, 2, &transaction.category_name_en)?;
+        worksheet.write(row, 3, transaction.amount)?;
+    }
+
+    workbook.save_to_buffer()
+}

--- a/server/src/features/transactions/download.rs
+++ b/server/src/features/transactions/download.rs
@@ -50,6 +50,17 @@ fn slugify(text: &str) -> String {
         .collect()
 }
 
+/// Prefixes `value` with a `'` if it starts with `=`, `+`, `-`, or `@`, which spreadsheet apps
+/// (Excel, Google Sheets) treat as the start of a formula. Without this, a user-controlled field
+/// like merchant or category name (e.g. `=SUM(A1:A2)`) would execute as a formula when the CSV is
+/// opened, rather than being displayed as plain text (CSV/formula injection).
+fn escape_formula(value: &str) -> String {
+    match value.chars().next() {
+        Some('=' | '+' | '-' | '@') => format!("'{value}"),
+        _ => value.to_string(),
+    }
+}
+
 /// Renders transactions as CSV bytes, with a header row.
 pub fn to_csv(transactions: &[Transaction]) -> Result<Vec<u8>, csv::Error> {
     let mut writer = csv::Writer::from_writer(Vec::new());
@@ -58,8 +69,8 @@ pub fn to_csv(transactions: &[Transaction]) -> Result<Vec<u8>, csv::Error> {
     for transaction in transactions {
         writer.write_record([
             transaction.date.to_string(),
-            transaction.merchant.clone(),
-            transaction.category_name_en.clone(),
+            escape_formula(&transaction.merchant),
+            escape_formula(&transaction.category_name_en),
             transaction.amount.to_string(),
         ])?;
     }

--- a/server/src/features/transactions/handlers.rs
+++ b/server/src/features/transactions/handlers.rs
@@ -6,6 +6,7 @@ use log::error;
 use serde::Deserialize;
 use sqlx::PgPool;
 
+use super::download;
 use super::model::{NewTransaction, TransactionFilter, TransactionPatch};
 use super::repository;
 use crate::shared::http_error::{
@@ -17,6 +18,21 @@ use crate::shared::l10n::L10n;
 #[derive(Deserialize)]
 struct TransactionIdPath {
     id: u32,
+}
+
+/// File format for `GET /transactions/download`.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum DownloadFormat {
+    Csv,
+    Xlsx,
+}
+
+/// Query params for `GET /transactions/download`, parsed independently from `TransactionFilter`
+/// since both are read from the same query string.
+#[derive(Deserialize)]
+struct DownloadFormatQuery {
+    format: DownloadFormat,
 }
 
 /// `POST /transactions` — create a transaction.
@@ -58,6 +74,63 @@ async fn list_transactions(
             error!("failed to list transactions error={e}");
             internal_error_response(&l10n, &l10n.locale())
         }
+    }
+}
+
+/// `GET /transactions/download` — download the same (filtered/sorted) transactions as
+/// `GET /transactions`, rendered as a CSV or Excel file. Accepts the same `date`, `merchant`,
+/// `search`, and `order` query params, plus `format` (`csv` or `xlsx`).
+async fn download_transactions(
+    filter: web::Query<TransactionFilter>,
+    format: web::Query<DownloadFormatQuery>,
+    pool: web::Data<PgPool>,
+    l10n: web::Data<L10n>,
+) -> impl Responder {
+    let locale = l10n.locale();
+
+    let transactions = match repository::list(&pool, &filter).await {
+        Ok(transactions) => transactions,
+        Err(e) => {
+            error!("failed to list transactions for download error={e}");
+            return internal_error_response(&l10n, &locale);
+        }
+    };
+
+    match format.format {
+        DownloadFormat::Csv => match download::to_csv(&transactions) {
+            Ok(bytes) => {
+                let filename = download::filename(&filter, "csv");
+                HttpResponse::Ok()
+                    .content_type("text/csv; charset=utf-8")
+                    .insert_header((
+                        "Content-Disposition",
+                        format!("attachment; filename=\"{filename}\""),
+                    ))
+                    .body(bytes)
+            }
+            Err(e) => {
+                error!("failed to render transactions as csv error={e}");
+                internal_error_response(&l10n, &locale)
+            }
+        },
+        DownloadFormat::Xlsx => match download::to_xlsx(&transactions) {
+            Ok(bytes) => {
+                let filename = download::filename(&filter, "xlsx");
+                HttpResponse::Ok()
+                    .content_type(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    )
+                    .insert_header((
+                        "Content-Disposition",
+                        format!("attachment; filename=\"{filename}\""),
+                    ))
+                    .body(bytes)
+            }
+            Err(e) => {
+                error!("failed to render transactions as xlsx error={e}");
+                internal_error_response(&l10n, &locale)
+            }
+        },
     }
 }
 
@@ -130,6 +203,10 @@ async fn delete_transaction(
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.route("/transactions", web::get().to(list_transactions))
         .route("/transactions", web::post().to(create_transaction))
+        .route(
+            "/transactions/download",
+            web::get().to(download_transactions),
+        )
         .route("/transactions/{id}", web::get().to(get_transaction))
         .route("/transactions/{id}", web::patch().to(update_transaction))
         .route("/transactions/{id}", web::delete().to(delete_transaction));

--- a/server/src/features/transactions/mod.rs
+++ b/server/src/features/transactions/mod.rs
@@ -1,3 +1,4 @@
+mod download;
 mod handlers;
 mod model;
 mod repository;

--- a/server/src/features/transactions/tests.rs
+++ b/server/src/features/transactions/tests.rs
@@ -421,6 +421,136 @@ async fn list_transactions_rejects_invalid_order(pool: PgPool) {
     assert_eq!(resp.status(), 400);
 }
 
+// --- GET /transactions/download ---
+
+#[sqlx::test]
+async fn download_transactions_csv_contains_header_and_rows(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+    create_via_api(&app, "2024-01-16", "IGA", "56.78").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions/download?format=csv")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "text/csv; charset=utf-8"
+    );
+    assert_eq!(
+        resp.headers().get("content-disposition").unwrap(),
+        "attachment; filename=\"transactions.csv\""
+    );
+    let body = test::read_body(resp).await;
+    let csv = String::from_utf8(body.to_vec()).unwrap();
+    let mut lines = csv.lines();
+    assert_eq!(lines.next().unwrap(), "Date,Merchant,Category,Amount");
+    assert_eq!(lines.next().unwrap(), "2024-01-16,IGA,Other,56.78");
+    assert_eq!(lines.next().unwrap(), "2024-01-15,STARBUCKS,Other,12.34");
+}
+
+#[sqlx::test]
+async fn download_transactions_filename_reflects_search_and_order(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions/download?format=csv&search=Coffee%20Shop!&order=amount")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get("content-disposition").unwrap(),
+        "attachment; filename=\"transactions_coffee-shop_highest-amount.csv\""
+    );
+}
+
+#[sqlx::test]
+async fn download_transactions_xlsx_returns_xlsx_content_type(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions/download?format=xlsx")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
+    let body = test::read_body(resp).await;
+    // .xlsx files are zip archives, which always start with the "PK" magic bytes.
+    assert_eq!(&body[0..2], b"PK");
+}
+
+#[sqlx::test]
+async fn download_transactions_respects_search_filter(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+    create_via_api(&app, "2024-01-16", "IGA", "56.78").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions/download?format=csv&search=starb")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body = test::read_body(resp).await;
+    let csv = String::from_utf8(body.to_vec()).unwrap();
+    let mut lines = csv.lines();
+    assert_eq!(lines.next().unwrap(), "Date,Merchant,Category,Amount");
+    assert_eq!(lines.next().unwrap(), "2024-01-15,STARBUCKS,Other,12.34");
+    assert!(lines.next().is_none());
+}
+
+#[sqlx::test]
+async fn download_transactions_respects_order(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+    create_via_api(&app, "2024-01-16", "IGA", "56.78").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions/download?format=csv&order=inverse_date")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body = test::read_body(resp).await;
+    let csv = String::from_utf8(body.to_vec()).unwrap();
+    let mut lines = csv.lines().skip(1);
+    assert_eq!(lines.next().unwrap(), "2024-01-15,STARBUCKS,Other,12.34");
+    assert_eq!(lines.next().unwrap(), "2024-01-16,IGA,Other,56.78");
+}
+
+#[sqlx::test]
+async fn download_transactions_rejects_missing_format(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions/download")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 400);
+}
+
+#[sqlx::test]
+async fn download_transactions_rejects_invalid_format(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions/download?format=pdf")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 400);
+}
+
 // --- GET /transactions/{id} ---
 
 #[sqlx::test]

--- a/server/src/features/transactions/tests.rs
+++ b/server/src/features/transactions/tests.rs
@@ -452,6 +452,60 @@ async fn download_transactions_csv_contains_header_and_rows(pool: PgPool) {
 }
 
 #[sqlx::test]
+async fn download_transactions_csv_escapes_formula_like_merchant(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    create_via_api(&app, "2024-01-15", "=SUM(A1:A2)", "12.34").await;
+    create_via_api(&app, "2024-01-16", "+1234567890", "20.00").await;
+    create_via_api(&app, "2024-01-17", "-2+3", "30.00").await;
+    create_via_api(&app, "2024-01-18", "@SUM(A1)", "40.00").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions/download?format=csv&order=inverse_date")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body = test::read_body(resp).await;
+    let csv = String::from_utf8(body.to_vec()).unwrap();
+    let rows: Vec<&str> = csv.lines().skip(1).collect();
+    assert_eq!(rows[0], "2024-01-15,'=SUM(A1:A2),Other,12.34");
+    assert_eq!(rows[1], "2024-01-16,'+1234567890,Other,20.00");
+    assert_eq!(rows[2], "2024-01-17,'-2+3,Other,30.00");
+    assert_eq!(rows[3], "2024-01-18,'@SUM(A1),Other,40.00");
+}
+
+#[sqlx::test]
+async fn download_transactions_csv_escapes_formula_like_category(pool: PgPool) {
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(pool))
+            .app_data(web::Data::new(L10n::new()))
+            .configure(configure)
+            .configure(crate::features::categories::configure),
+    )
+    .await;
+    let patch_req = test::TestRequest::patch()
+        .uri("/categories/1")
+        .set_json(serde_json::json!({ "name_en": "=cmd", "name_fr": "Autre" }))
+        .to_request();
+    test::call_service(&app, patch_req).await;
+    create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;
+
+    let req = test::TestRequest::get()
+        .uri("/transactions/download?format=csv")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body = test::read_body(resp).await;
+    let csv = String::from_utf8(body.to_vec()).unwrap();
+    assert_eq!(
+        csv.lines().nth(1).unwrap(),
+        "2024-01-15,STARBUCKS,'=cmd,12.34"
+    );
+}
+
+#[sqlx::test]
 async fn download_transactions_filename_reflects_search_and_order(pool: PgPool) {
     let app = test::init_service(app_with(pool)).await;
     create_via_api(&app, "2024-01-15", "STARBUCKS", "12.34").await;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -24,10 +24,13 @@ async fn main() -> std::io::Result<()> {
     // Actix web server configuration
     HttpServer::new(move || {
         // Dev-only: allows the Vite client (a different origin) to call this API.
+        // `Content-Disposition` must be explicitly exposed, or the browser's `fetch()` can't read
+        // the filename off download responses (it's not on the CORS response-header safelist).
         let cors = Cors::default()
             .allowed_origin("http://localhost:5173")
             .allow_any_method()
-            .allow_any_header();
+            .allow_any_header()
+            .expose_headers(["Content-Disposition"]);
 
         App::new()
             .wrap(cors)


### PR DESCRIPTION
New GET /transactions/download endpoint reuses the existing list repository function (so filtering/sorting logic isn't duplicated), accepting the same date/merchant/search/order params as GET /transactions plus format=csv|xlsx. Renders CSV via the csv crate and .xlsx via rust_xlsxwriter, with columns Date, Merchant, Category, Amount, and names the file after the applied filters (e.g. transactions_maxi_highest-amount.csv).

The client's Download button (same anchored-popover pattern as Search/Sort) offers CSV/Excel, fetches from the endpoint using the current search/order from the route, and saves using the filename the server sent back via Content-Disposition.

Also exposes Content-Disposition via CORS (Access-Control-Expose-Headers) so the browser's fetch() can actually read that filename cross-origin - without it the client silently fell back to a static "transactions.csv".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction downloads in CSV and Excel formats.
  * Downloads use the current search and sort filters and save with descriptive filenames.
  * Introduced a dedicated downloads menu with improved accessibility, focus, and keyboard handling.
* **Bug Fixes**
  * Added an error notification when a transaction download fails.
  * Prevented spreadsheet formula injection by escaping formula-like fields in exported CSV.
  * Updated browser handling to expose downloaded filenames via the attachment header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->