### PR TITLE
Feature: Add Import action to Transactions page

### DIFF
--- a/.claude/skills/budget-file-to-transaction/SKILL.md
+++ b/.claude/skills/budget-file-to-transaction/SKILL.md
@@ -1,22 +1,29 @@
 ---
 name: budget-file-to-transaction
 description: >-
-  Converts budget exports into transactions and inserts them into the local
-  database via the server's API. Do not apply from context alone; only when
-  the user explicitly requests this skill by name (budget-file-to-transaction)
-  or says to use the budget-to-transaction workflow.
+  Converts a budget export into transactions and inserts them into the local
+  database via the server's API. Unattended — invoked only by the server's
+  `POST /transactions/import` background job, never interactively. Do not
+  apply from context alone; only when the invocation explicitly names this
+  skill and supplies a `job_id`.
 ---
 
 # Budget file → Transaction
 
-**Invocation only** — apply only when explicitly requested by name.
+**Unattended only.** This runs as a server-spawned subprocess with no human present to confirm
+anything and no session persistence — there is exactly one chance to get it right, and exactly one
+chance to report the result back. Only `Read` and the three `curl` prefixes below are pre-approved;
+anything else is denied automatically, so stick to the calls shown here exactly.
+
+The invocation gives a file path and a `job_id`. If either is missing, stop and report `failed`
+via the final `PATCH` (see Steps) with an `error_message` explaining what's missing — do not guess.
 
 ## Output
 
-`POST http://127.0.0.1:3055/transactions` per transaction (server must be running via `cargo run` in `server/`).
+`POST http://127.0.0.1:3055/transactions` per transaction (server must be running).
 
 ```json
-{ "date": "2024-01-15", "merchant": "STARBUCKS", "amount": "12.34", "category_id": 12, "account": "User 1" }
+{ "date": "2024-01-15", "merchant": "STARBUCKS", "amount": "12.34", "category_id": 12, "account": "User 1", "reviewed": false }
 ```
 
 - `date` — `YYYY-MM-DD`.
@@ -24,24 +31,41 @@ description: >-
 - `amount` — always positive, no currency symbol. Expenses and income (deposits, paycheck, e-transfers) are both positive; direction is shown by category, not sign.
 - `category_id` — id of the best-matching row from `GET http://127.0.0.1:3055/categories` (see Steps). Use the `Unknown` category's id if nothing fits.
 - `account` — `User 1` unless the source says otherwise.
+- `reviewed` — always `false`. No human confirmed these rows; this flags them for later review.
 
 ## Steps
 
-1. `GET /categories` once; keep the returned `id`/`name_en`/`name_fr`/`type` list for matching.
-2. Parse the source: detect format, skip headers/totals/blanks, map columns, normalize dates/amounts/merchant.
+1. Fetch categories once, using exactly this command (matches the pre-approved allowlist —
+   don't add flags like `-s`, they can cause the call to be denied):
+   ```bash
+   curl http://127.0.0.1:3055/categories
+   ```
+   Keep the returned `id`/`name_en`/`name_fr`/`type` list for matching.
+2. Read and parse the source file: detect format, skip headers/totals/blanks, map columns, normalize dates/amounts/merchant.
 3. For each row, match its best-guess category name against the fetched list (by `name_en` or `name_fr`); fall back to `Unknown` if nothing fits.
-4. Preview every row (date, merchant, amount, category name, account) plus skip count; wait for confirmation.
-5. On confirmation, `POST` each row; track successes/failures.
-6. Report created/failed/skipped counts.
+4. `POST` each row with `"reviewed": false`; track successes/failures/skips. No preview, no confirmation step — go straight from matching to posting.
+5. Report the result with exactly one final call, matching one of:
+   ```bash
+   curl -X PATCH http://127.0.0.1:3055/transactions/import/jobs/{job_id} \
+     -H "Content-Type: application/json" \
+     -d '{"status":"succeeded","created_count":N,"failed_count":M,"skipped_count":K}'
+   ```
+   ```bash
+   curl -X PATCH http://127.0.0.1:3055/transactions/import/jobs/{job_id} \
+     -H "Content-Type: application/json" \
+     -d '{"status":"failed","error_message":"<what went wrong>"}'
+   ```
+   Use `failed` if the file couldn't be parsed at all or every row failed to post; `succeeded`
+   otherwise, even if some rows were skipped or failed individually (their counts say so). If this
+   call is skipped, the server falls back to marking the job failed on its own once the subprocess
+   exits, using whatever it printed as the error message — so still worth getting this right.
 
 ## Example
 
-`01/15/2024,STARBUCKS,-12.34,Restaurant` → preview row `2024-01-15 | STARBUCKS | 12.34 | Restaurant | User 1` → matched `Restaurant` to id `12` → on confirmation:
+`01/15/2024,STARBUCKS,-12.34,Restaurant` → matched `Restaurant` to id `12`:
 
 ```bash
 curl -X POST http://127.0.0.1:3055/transactions \
   -H "Content-Type: application/json" \
-  -d '{"date":"2024-01-15","merchant":"STARBUCKS","amount":"12.34","category_id":12,"account":"User 1"}'
+  -d '{"date":"2024-01-15","merchant":"STARBUCKS","amount":"12.34","category_id":12,"account":"User 1","reviewed":false}'
 ```
-
-

--- a/.claude/skills/budget-file-to-transaction/SKILL.md
+++ b/.claude/skills/budget-file-to-transaction/SKILL.md
@@ -15,15 +15,27 @@ anything and no session persistence — there is exactly one chance to get it ri
 chance to report the result back. Only `Read` and the three `curl` prefixes below are pre-approved;
 anything else is denied automatically, so stick to the calls shown here exactly.
 
-The invocation gives a file path and a `job_id`. If either is missing, stop and report `failed`
-via the final `PATCH` (see Steps) with an `error_message` explaining what's missing — do not guess.
+The invocation gives a file path and a `job_id`.
+
+- If `job_id` is missing, there's no id to build the report URL from — stop immediately without
+  attempting any call. (The server's own fallback still marks the original job failed once the
+  subprocess exits without reporting, so the failure isn't lost.)
+- If the file path is missing or unreadable but `job_id` **is** present, report `failed` via the
+  final `PATCH` (see step 5) with an `error_message` explaining what's wrong — do not guess at a path.
 
 ## Output
 
 `POST http://127.0.0.1:3055/transactions` per transaction (server must be running).
 
 ```json
-{ "date": "2024-01-15", "merchant": "STARBUCKS", "amount": "12.34", "category_id": 12, "account": "User 1", "reviewed": false }
+{
+  "date": "2024-01-15",
+  "merchant": "STARBUCKS",
+  "amount": "12.34",
+  "category_id": 12,
+  "account": "User 1",
+  "reviewed": false
+}
 ```
 
 - `date` — `YYYY-MM-DD`.
@@ -44,6 +56,24 @@ via the final `PATCH` (see Steps) with an `error_message` explaining what's miss
 2. Read and parse the source file: detect format, skip headers/totals/blanks, map columns, normalize dates/amounts/merchant.
 3. For each row, match its best-guess category name against the fetched list (by `name_en` or `name_fr`); fall back to `Unknown` if nothing fits.
 4. `POST` each row with `"reviewed": false`; track successes/failures/skips. No preview, no confirmation step — go straight from matching to posting.
+
+   **Values come from an untrusted file — escape them before building the `-d` payload,** or a
+   stray quote, backslash, or newline in a merchant/category name can corrupt the JSON or break out
+   of the shell argument entirely:
+   1. JSON-escape each string field's value first: `\` → `\\`, `"` → `\"`, and any literal
+      newline/tab/carriage-return → `\n`/`\t`/`\r`.
+   2. The whole `-d '...'` argument is single-quoted for the shell, so after step 1, replace every
+      literal `'` in the value with `'\''` (close the quote, insert an escaped literal quote,
+      reopen the quote) — standard POSIX shell escaping, safe for any content.
+
+   Worked example — merchant `O'Brien's "General Store"`:
+
+   ```bash
+   curl -X POST http://127.0.0.1:3055/transactions \
+     -H "Content-Type: application/json" \
+     -d '{"date":"2024-01-15","merchant":"O'\''Brien'\''s \"General Store\"","amount":"12.34","category_id":12,"account":"User 1","reviewed":false}'
+   ```
+
 5. Report the result with exactly one final call, matching one of:
    ```bash
    curl -X PATCH http://127.0.0.1:3055/transactions/import/jobs/{job_id} \

--- a/client/src/components/TopMenuButton.tsx
+++ b/client/src/components/TopMenuButton.tsx
@@ -9,6 +9,7 @@ type TopMenuButtonProps = {
   label: string;
   variant?: 'default' | 'primary';
   spin?: boolean;
+  disabled?: boolean;
   onClick?: () => void;
   'aria-haspopup'?: AriaAttributes['aria-haspopup'];
   'aria-expanded'?: boolean;
@@ -21,6 +22,7 @@ export const TopMenuButton = forwardRef<HTMLButtonElement, TopMenuButtonProps>(
       label,
       variant = 'default',
       spin = false,
+      disabled = false,
       onClick,
       'aria-haspopup': ariaHasPopup,
       'aria-expanded': ariaExpanded,
@@ -36,6 +38,7 @@ export const TopMenuButton = forwardRef<HTMLButtonElement, TopMenuButtonProps>(
           : 'top-menu-button'
       }
       onClick={onClick}
+      disabled={disabled}
       aria-haspopup={ariaHasPopup}
       aria-expanded={ariaExpanded}
     >

--- a/client/src/components/TopMenuButton.tsx
+++ b/client/src/components/TopMenuButton.tsx
@@ -8,6 +8,7 @@ type TopMenuButtonProps = {
   icon: IconDefinition;
   label: string;
   variant?: 'default' | 'primary';
+  spin?: boolean;
   onClick?: () => void;
   'aria-haspopup'?: AriaAttributes['aria-haspopup'];
   'aria-expanded'?: boolean;
@@ -19,6 +20,7 @@ export const TopMenuButton = forwardRef<HTMLButtonElement, TopMenuButtonProps>(
       icon,
       label,
       variant = 'default',
+      spin = false,
       onClick,
       'aria-haspopup': ariaHasPopup,
       'aria-expanded': ariaExpanded,
@@ -37,7 +39,7 @@ export const TopMenuButton = forwardRef<HTMLButtonElement, TopMenuButtonProps>(
       aria-haspopup={ariaHasPopup}
       aria-expanded={ariaExpanded}
     >
-      <FontAwesomeIcon icon={icon} />
+      <FontAwesomeIcon icon={icon} spin={spin} />
       <span>{label}</span>
     </button>
   ),

--- a/client/src/features/transactions/ImportButton.tsx
+++ b/client/src/features/transactions/ImportButton.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { faFileImport, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { TopMenuButton } from '../../components/TopMenuButton';
+import { useImportJob } from './use-import-job';
+import { startImport } from './import';
+import {
+  importFailedToast,
+  importStartedToast,
+  importSucceededToast,
+} from '../../lib/toast';
+
+export const ImportButton = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [jobId, setJobId] = useState<string>();
+  const queryClient = useQueryClient();
+
+  const { data: job } = useImportJob(jobId);
+
+  useEffect(() => {
+    if (!job) return;
+    if (job.status === 'succeeded') {
+      importSucceededToast(job.created_count ?? 0);
+      queryClient.invalidateQueries({ queryKey: ['transactions'] });
+      setJobId(undefined);
+    } else if (job.status === 'failed') {
+      importFailedToast();
+      setJobId(undefined);
+    }
+  }, [job, queryClient]);
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+
+    try {
+      const startedJob = await startImport(file);
+      setJobId(startedJob.id);
+      importStartedToast();
+    } catch {
+      importFailedToast();
+    }
+  };
+
+  return (
+    <>
+      <input ref={inputRef} type="file" hidden onChange={handleFileChange} />
+      <TopMenuButton
+        icon={jobId ? faSpinner : faFileImport}
+        spin={jobId !== undefined}
+        label={
+          jobId
+            ? job?.status === 'pending'
+              ? 'Uploading…'
+              : 'Importing…'
+            : 'Import'
+        }
+        onClick={() => inputRef.current?.click()}
+      />
+    </>
+  );
+};

--- a/client/src/features/transactions/ImportButton.tsx
+++ b/client/src/features/transactions/ImportButton.tsx
@@ -7,21 +7,30 @@ import { useImportJob } from './use-import-job';
 import { startImport } from './import';
 import {
   importFailedToast,
+  importPartialToast,
   importStartedToast,
   importSucceededToast,
 } from '../../lib/toast';
 
 export const ImportButton = () => {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
   const [jobId, setJobId] = useState<string>();
   const queryClient = useQueryClient();
 
   const { data: job } = useImportJob(jobId);
+  const busy = isUploading || jobId !== undefined;
 
   useEffect(() => {
     if (!job) return;
     if (job.status === 'succeeded') {
-      importSucceededToast(job.created_count ?? 0);
+      const failedCount = job.failed_count ?? 0;
+      const skippedCount = job.skipped_count ?? 0;
+      if (failedCount > 0 || skippedCount > 0) {
+        importPartialToast(job.created_count ?? 0, failedCount, skippedCount);
+      } else {
+        importSucceededToast(job.created_count ?? 0);
+      }
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
       setJobId(undefined);
     } else if (job.status === 'failed') {
@@ -33,30 +42,34 @@ export const ImportButton = () => {
   const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     event.target.value = '';
-    if (!file) return;
+    if (!file || busy) return;
 
+    setIsUploading(true);
     try {
       const startedJob = await startImport(file);
       setJobId(startedJob.id);
       importStartedToast();
     } catch {
       importFailedToast();
+    } finally {
+      setIsUploading(false);
     }
   };
 
   return (
     <>
-      <input ref={inputRef} type="file" hidden onChange={handleFileChange} />
+      <input
+        ref={inputRef}
+        type="file"
+        hidden
+        disabled={busy}
+        onChange={handleFileChange}
+      />
       <TopMenuButton
-        icon={jobId ? faSpinner : faFileImport}
-        spin={jobId !== undefined}
-        label={
-          jobId
-            ? job?.status === 'pending'
-              ? 'Uploading…'
-              : 'Importing…'
-            : 'Import'
-        }
+        icon={busy ? faSpinner : faFileImport}
+        spin={busy}
+        disabled={busy}
+        label={busy ? (isUploading ? 'Uploading…' : 'Importing…') : 'Import'}
         onClick={() => inputRef.current?.click()}
       />
     </>

--- a/client/src/features/transactions/import.ts
+++ b/client/src/features/transactions/import.ts
@@ -1,0 +1,12 @@
+import { apiFetch, apiFetchUpload } from '../../lib/api-client';
+import type { ImportJob } from './types';
+
+/** Uploads a budget file for the server to import in the background; returns the created job. */
+export const startImport = async (file: File): Promise<ImportJob> => {
+  const formData = new FormData();
+  formData.set('file', file);
+  return apiFetchUpload<ImportJob>('/transactions/import', formData);
+};
+
+export const getImportJob = (id: string): Promise<ImportJob> =>
+  apiFetch<ImportJob>(`/transactions/import/jobs/${id}`);

--- a/client/src/features/transactions/types.ts
+++ b/client/src/features/transactions/types.ts
@@ -10,5 +10,20 @@ export interface Transaction {
   category_name_fr: string;
   category_type: 'income' | 'expense' | 'transfer';
   account: string;
+  reviewed: boolean;
   created_at: string;
+}
+
+export type ImportJobStatus = 'pending' | 'running' | 'succeeded' | 'failed';
+
+export interface ImportJob {
+  id: string;
+  status: ImportJobStatus;
+  file_name: string;
+  created_count: number | null;
+  failed_count: number | null;
+  skipped_count: number | null;
+  error_message: string | null;
+  created_at: string;
+  updated_at: string;
 }

--- a/client/src/features/transactions/use-import-job.ts
+++ b/client/src/features/transactions/use-import-job.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { getImportJob } from './import';
+
+const isTerminal = (status?: string) =>
+  status === 'succeeded' || status === 'failed';
+
+/** Polls an import job's status until it reaches a terminal state (succeeded/failed). */
+export const useImportJob = (jobId?: string) =>
+  useQuery({
+    queryKey: ['import-job', jobId ?? null],
+    queryFn: () => getImportJob(jobId!),
+    enabled: jobId !== undefined,
+    refetchInterval: (query) =>
+      isTerminal(query.state.data?.status) ? false : 2000,
+  });

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -14,6 +14,7 @@
   --color-dark: #313133; /* Alternate background */
   --color-background: #131314; /* Background */
   --color-success: #3ba27a; /* Positive amounts, success states */
+  --color-warning: #e5a13b; /* Partial-success/caution states */
   --color-error: #e5484d; /* Negative amounts, error states */
 
   /* Spacing */

--- a/client/src/lib/api-client.ts
+++ b/client/src/lib/api-client.ts
@@ -18,6 +18,22 @@ export const apiFetch = async <T>(
   return response.json() as Promise<T>;
 };
 
+export const apiFetchUpload = async <T>(
+  path: string,
+  formData: FormData,
+): Promise<T> => {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(`POST ${path} failed: ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+};
+
 /** Extracts the `filename` param from a `Content-Disposition: attachment; filename="..."` header. */
 const parseFilename = (contentDisposition: string | null): string | undefined =>
   contentDisposition?.match(/filename="([^"]+)"/)?.[1];

--- a/client/src/lib/toast.ts
+++ b/client/src/lib/toast.ts
@@ -16,3 +16,17 @@ export const importSucceededToast = (createdCount: number) =>
   toast.success(
     `Imported ${createdCount} transaction${createdCount === 1 ? '' : 's'}.`,
   );
+
+export const importPartialToast = (
+  createdCount: number,
+  failedCount: number,
+  skippedCount: number,
+) => {
+  const issues = [
+    failedCount > 0 ? `${failedCount} failed` : null,
+    skippedCount > 0 ? `${skippedCount} skipped` : null,
+  ].filter(Boolean);
+  toast.warning(
+    `Imported ${createdCount} transaction${createdCount === 1 ? '' : 's'} (${issues.join(', ')}).`,
+  );
+};

--- a/client/src/lib/toast.ts
+++ b/client/src/lib/toast.ts
@@ -5,3 +5,14 @@ export const notImplementedToast = () =>
 
 export const downloadFailedToast = () =>
   toast.error('Failed to download transactions.');
+
+export const importStartedToast = () =>
+  toast('Import started — this can take a minute.');
+
+export const importFailedToast = () =>
+  toast.error('Failed to import transactions.');
+
+export const importSucceededToast = (createdCount: number) =>
+  toast.success(
+    `Imported ${createdCount} transaction${createdCount === 1 ? '' : 's'}.`,
+  );

--- a/client/src/routes/__root.css
+++ b/client/src/routes/__root.css
@@ -41,3 +41,7 @@
 [data-sonner-toast][data-type='error'] [data-icon] {
   color: var(--color-error);
 }
+
+[data-sonner-toast][data-type='success'] [data-icon] {
+  color: var(--color-success);
+}

--- a/client/src/routes/__root.css
+++ b/client/src/routes/__root.css
@@ -45,3 +45,7 @@
 [data-sonner-toast][data-type='success'] [data-icon] {
   color: var(--color-success);
 }
+
+[data-sonner-toast][data-type='warning'] [data-icon] {
+  color: var(--color-warning);
+}

--- a/client/src/routes/transactions.tsx
+++ b/client/src/routes/transactions.tsx
@@ -2,13 +2,13 @@ import { createFileRoute, getRouteApi } from '@tanstack/react-router';
 import {
   faCalendarDays,
   faFilter,
-  faFileImport,
   faPlus,
 } from '@fortawesome/free-solid-svg-icons';
 import { TopMenuButton } from '../components/TopMenuButton';
 import { TransactionsList } from '../features/transactions/TransactionsList';
 import { SearchButton } from '../features/transactions/SearchButton';
 import { DownloadButton } from '../features/transactions/DownloadButton';
+import { ImportButton } from '../features/transactions/ImportButton';
 import { notImplementedToast } from '../lib/toast';
 import type { SortOrder } from '../features/transactions/types';
 import '../components/TopMenu.css';
@@ -55,11 +55,7 @@ const TransactionsTopMenuActions = () => (
       label="Filters"
       onClick={notImplementedToast}
     />
-    <TopMenuButton
-      icon={faFileImport}
-      label="Import"
-      onClick={notImplementedToast}
-    />
+    <ImportButton />
     <DownloadButton />
     <TopMenuButton
       icon={faPlus}

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2689,7 +2689,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "daa239b93927be1ff123eebada5a3ff23e89f0124ccb8609234e5103d5a5ae6d"
 dependencies = [
  "actix-utils",
  "actix-web",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-util",
  "log",
  "once_cell",
@@ -49,7 +49,7 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
  "flate2",
  "foldhash",
@@ -79,6 +79,44 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "actix-multipart"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5118a26dee7e34e894f7e85aa0ee5080ae4c18bf03c0e30d49a80e418f00a53"
+dependencies = [
+ "actix-multipart-derive",
+ "actix-utils",
+ "actix-web",
+ "derive_more 0.99.20",
+ "futures-core",
+ "futures-util",
+ "httparse",
+ "local-waker",
+ "log",
+ "memchr",
+ "mime",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "actix-multipart-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11eb847f49a700678ea2fa73daeb3208061afa2b9d1a8527c03390f4c4a1c6b"
+dependencies = [
+ "darling",
+ "parse-size",
+ "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
@@ -164,7 +202,7 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
  "foldhash",
  "futures-core",
@@ -524,6 +562,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -628,6 +672,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +728,19 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -662,7 +754,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -777,6 +869,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -977,8 +1075,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1203,6 +1312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,6 +1478,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1540,6 +1661,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1811,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -1911,6 +2044,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,6 +2145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,6 +2171,7 @@ version = "0.1.0"
 dependencies = [
  "actix-cors",
  "actix-http",
+ "actix-multipart",
  "actix-web",
  "chrono",
  "csv",
@@ -2028,7 +2184,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tokio",
  "unic-langid",
+ "uuid",
 ]
 
 [[package]]
@@ -2358,6 +2516,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2565,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -2709,7 +2886,9 @@ version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,3 +24,4 @@ uuid = { version = "1", features = ["v4", "serde"] }
 [dev-dependencies]
 actix-http = "3"
 serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 actix-cors = "0.7.1"
+actix-multipart = "0.7"
 actix-web = "4.13.0"
 chrono = { version = "0.4", features = ["serde"] }
 csv = "1"
@@ -16,7 +17,9 @@ rust_decimal = { version = "1", features = ["serde-with-str"] }
 rust_xlsxwriter = { version = "0.96", features = ["rust_decimal", "chrono"] }
 serde = { version = "1.0.228", features = ["derive"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "migrate", "chrono", "rust_decimal"] }
+tokio = { version = "1", features = ["process"] }
 unic-langid = "0.9"
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 actix-http = "3"

--- a/server/locales/en.ftl
+++ b/server/locales/en.ftl
@@ -5,4 +5,7 @@ category-not-found = No category with id { $n }
 category-duplicate-name = A category with this name already exists
 category-invalid-type = type must be one of income, expense, or transfer
 category-in-use = Category { $n } is still used by existing transactions
+import-job-not-found = No import job found
+import-file-required = A file to import is required
+import-file-too-large = The uploaded file is too large (10 MB max)
 internal-db-error = Internal server error

--- a/server/locales/fr.ftl
+++ b/server/locales/fr.ftl
@@ -5,4 +5,7 @@ category-not-found = Aucune catégorie avec l’id { $n }
 category-duplicate-name = Une catégorie avec ce nom existe déjà
 category-invalid-type = type doit être income, expense ou transfer
 category-in-use = La catégorie { $n } est toujours utilisée par des transactions existantes
+import-job-not-found = Aucune tâche d’importation avec cet identifiant
+import-file-required = Un fichier à importer est requis
+import-file-too-large = Le fichier téléversé est trop volumineux (10 Mo maximum)
 internal-db-error = Erreur interne du serveur

--- a/server/migrations/20260724152247_add_transactions_reviewed.sql
+++ b/server/migrations/20260724152247_add_transactions_reviewed.sql
@@ -1,0 +1,3 @@
+-- Transactions created interactively (or manually) default to reviewed; automated
+-- imports explicitly set this to false so they can be found and reviewed later.
+ALTER TABLE transactions ADD COLUMN reviewed BOOLEAN NOT NULL DEFAULT true;

--- a/server/src/features/transactions/handlers.rs
+++ b/server/src/features/transactions/handlers.rs
@@ -1,9 +1,11 @@
 //! HTTP API for transactions: JSON CRUD backed by Postgres, plus the async budget-file import.
 
 use actix_multipart::form::tempfile::TempFile;
-use actix_multipart::form::MultipartForm;
+use actix_multipart::form::{MultipartForm, MultipartFormConfig};
+use actix_multipart::MultipartError;
+use actix_web::error::{InternalError, PayloadError};
 use actix_web::http::StatusCode;
-use actix_web::{web, HttpResponse, Responder};
+use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use log::error;
 use serde::Deserialize;
 use sqlx::PgPool;
@@ -153,6 +155,28 @@ async fn download_transactions(
     }
 }
 
+/// Converts a multipart parsing/extraction failure — in practice almost always the 10 MB field
+/// size limit on `ImportUploadForm` being exceeded — into the same localized JSON error shape the
+/// rest of this API uses, instead of actix-multipart's plain-text default.
+fn import_upload_error_handler(err: MultipartError, req: &HttpRequest) -> actix_web::Error {
+    let response = match req.app_data::<web::Data<L10n>>() {
+        Some(l10n) => {
+            let locale = l10n.locale();
+            let message_id = match &err {
+                // The field-level `#[multipart(limit = "10MB")]` surfaces as a payload overflow,
+                // not `MultipartError::Field` — confirmed against a real oversized upload.
+                MultipartError::Payload(PayloadError::Overflow) | MultipartError::Field { .. } => {
+                    "import-file-too-large"
+                }
+                _ => "import-file-required",
+            };
+            error_response(l10n, &locale, StatusCode::BAD_REQUEST, message_id)
+        }
+        None => HttpResponse::BadRequest().finish(),
+    };
+    InternalError::from_response(err, response).into()
+}
+
 /// `POST /transactions/import` — accepts a single budget-export file, stages it to disk, and
 /// spawns an unattended `claude` subprocess (running the `budget-file-to-transaction` skill) to
 /// parse and import it in the background. Returns immediately with the job id; poll
@@ -165,7 +189,7 @@ async fn import_transactions(
     let locale = l10n.locale();
 
     let original_name = form.file.file_name.clone().unwrap_or_default();
-    if form.file.size == 0 || original_name.trim().is_empty() {
+    if !import::is_valid_upload(&original_name, form.file.size as u64) {
         return error_response(
             &l10n,
             &locale,
@@ -175,20 +199,14 @@ async fn import_transactions(
     }
 
     let job = job_store.create(import::sanitize_filename(&original_name));
-    let dest_dir = import::upload_dir(job.id);
-    let dest_path = dest_dir.join(import::sanitize_filename(&original_name));
-
-    if let Err(e) = tokio::fs::create_dir_all(&dest_dir).await {
-        error!(
-            "failed to create import upload dir job_id={} error={e}",
-            job.id
-        );
-        return internal_error_response(&l10n, &locale);
-    }
-    if let Err(e) = tokio::fs::copy(form.file.file.path(), &dest_path).await {
-        error!("failed to stage import upload job_id={} error={e}", job.id);
-        return internal_error_response(&l10n, &locale);
-    }
+    let dest_path = match import::stage_upload(job.id, &original_name, form.file.file.path()).await
+    {
+        Ok(dest_path) => dest_path,
+        Err(e) => {
+            error!("failed to stage import upload job_id={} error={e}", job.id);
+            return internal_error_response(&l10n, &locale);
+        }
+    };
 
     let job_store_for_task = job_store.clone();
     let job_id = job.id;
@@ -304,7 +322,8 @@ async fn delete_transaction(
 
 /// Registers the transactions feature's routes.
 pub fn configure(cfg: &mut web::ServiceConfig) {
-    cfg.route("/transactions", web::get().to(list_transactions))
+    cfg.app_data(MultipartFormConfig::default().error_handler(import_upload_error_handler))
+        .route("/transactions", web::get().to(list_transactions))
         .route("/transactions", web::post().to(create_transaction))
         .route(
             "/transactions/download",

--- a/server/src/features/transactions/handlers.rs
+++ b/server/src/features/transactions/handlers.rs
@@ -1,16 +1,22 @@
-//! HTTP API for transactions: JSON CRUD backed by Postgres.
+//! HTTP API for transactions: JSON CRUD backed by Postgres, plus the async budget-file import.
 
+use actix_multipart::form::tempfile::TempFile;
+use actix_multipart::form::MultipartForm;
 use actix_web::http::StatusCode;
 use actix_web::{web, HttpResponse, Responder};
 use log::error;
 use serde::Deserialize;
 use sqlx::PgPool;
+use uuid::Uuid;
 
 use super::download;
-use super::model::{NewTransaction, TransactionFilter, TransactionPatch};
+use super::import;
+use super::jobs::JobStore;
+use super::model::{ImportJobReport, NewTransaction, TransactionFilter, TransactionPatch};
 use super::repository;
 use crate::shared::http_error::{
-    error_response_with_n, internal_error_response, is_foreign_key_violation, not_found_response,
+    error_response, error_response_with_n, internal_error_response, is_foreign_key_violation,
+    not_found_response,
 };
 use crate::shared::l10n::L10n;
 
@@ -18,6 +24,19 @@ use crate::shared::l10n::L10n;
 #[derive(Deserialize)]
 struct TransactionIdPath {
     id: u32,
+}
+
+/// Import job id path (`/transactions/import/jobs/{id}`)
+#[derive(Deserialize)]
+struct ImportJobIdPath {
+    id: Uuid,
+}
+
+/// Multipart body for `POST /transactions/import`: a single file field, capped at 10 MB.
+#[derive(MultipartForm)]
+struct ImportUploadForm {
+    #[multipart(limit = "10MB")]
+    file: TempFile,
 }
 
 /// File format for `GET /transactions/download`.
@@ -134,6 +153,90 @@ async fn download_transactions(
     }
 }
 
+/// `POST /transactions/import` — accepts a single budget-export file, stages it to disk, and
+/// spawns an unattended `claude` subprocess (running the `budget-file-to-transaction` skill) to
+/// parse and import it in the background. Returns immediately with the job id; poll
+/// `GET /transactions/import/jobs/{id}` for status.
+async fn import_transactions(
+    MultipartForm(form): MultipartForm<ImportUploadForm>,
+    job_store: web::Data<JobStore>,
+    l10n: web::Data<L10n>,
+) -> impl Responder {
+    let locale = l10n.locale();
+
+    let original_name = form.file.file_name.clone().unwrap_or_default();
+    if form.file.size == 0 || original_name.trim().is_empty() {
+        return error_response(
+            &l10n,
+            &locale,
+            StatusCode::BAD_REQUEST,
+            "import-file-required",
+        );
+    }
+
+    let job = job_store.create(import::sanitize_filename(&original_name));
+    let dest_dir = import::upload_dir(job.id);
+    let dest_path = dest_dir.join(import::sanitize_filename(&original_name));
+
+    if let Err(e) = tokio::fs::create_dir_all(&dest_dir).await {
+        error!(
+            "failed to create import upload dir job_id={} error={e}",
+            job.id
+        );
+        return internal_error_response(&l10n, &locale);
+    }
+    if let Err(e) = tokio::fs::copy(form.file.file.path(), &dest_path).await {
+        error!("failed to stage import upload job_id={} error={e}", job.id);
+        return internal_error_response(&l10n, &locale);
+    }
+
+    let job_store_for_task = job_store.clone();
+    let job_id = job.id;
+    tokio::spawn(async move {
+        import::run_import(&job_store_for_task, job_id, dest_path).await;
+    });
+
+    HttpResponse::Accepted()
+        .insert_header(("Location", format!("/transactions/import/jobs/{}", job.id)))
+        .json(job)
+}
+
+/// `GET /transactions/import/jobs/{id}` — poll the status of an import job.
+async fn get_import_job(
+    path: web::Path<ImportJobIdPath>,
+    job_store: web::Data<JobStore>,
+    l10n: web::Data<L10n>,
+) -> impl Responder {
+    match job_store.get(path.id) {
+        Some(job) => HttpResponse::Ok().json(job),
+        None => error_response(
+            &l10n,
+            &l10n.locale(),
+            StatusCode::NOT_FOUND,
+            "import-job-not-found",
+        ),
+    }
+}
+
+/// `PATCH /transactions/import/jobs/{id}` — how the unattended import subprocess reports its own
+/// final result back to the server (see the skill's "Unattended mode" section). Not intended to
+/// be called from the client.
+async fn report_import_job(
+    path: web::Path<ImportJobIdPath>,
+    report: web::Json<ImportJobReport>,
+    job_store: web::Data<JobStore>,
+) -> impl Responder {
+    job_store.complete(
+        path.id,
+        report.status,
+        report.created_count,
+        report.failed_count,
+        report.skipped_count,
+        report.error_message.clone(),
+    );
+    HttpResponse::NoContent().finish()
+}
+
 /// `GET /transactions/{id}` — fetch a single transaction.
 async fn get_transaction(
     path: web::Path<TransactionIdPath>,
@@ -206,6 +309,15 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         .route(
             "/transactions/download",
             web::get().to(download_transactions),
+        )
+        .route("/transactions/import", web::post().to(import_transactions))
+        .route(
+            "/transactions/import/jobs/{id}",
+            web::get().to(get_import_job),
+        )
+        .route(
+            "/transactions/import/jobs/{id}",
+            web::patch().to(report_import_job),
         )
         .route("/transactions/{id}", web::get().to(get_transaction))
         .route("/transactions/{id}", web::patch().to(update_transaction))

--- a/server/src/features/transactions/import.rs
+++ b/server/src/features/transactions/import.rs
@@ -1,0 +1,181 @@
+//! Drives an unattended `claude` subprocess through the `budget-file-to-transaction` skill for
+//! `POST /transactions/import`. The subprocess talks to this same server's API directly (see the
+//! skill's "Unattended mode" section); this module only stages the uploaded file, launches the
+//! subprocess with a narrow tool allowlist, and falls back to marking the job failed if the
+//! subprocess never reports its own result.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use tokio::process::Command;
+use uuid::Uuid;
+
+use super::jobs::JobStore;
+use super::model::ImportJobStatus;
+
+/// Local address the server binds to (see `main.rs`) and that the subprocess calls back into.
+const SERVER_ADDR: &str = "127.0.0.1:3055";
+
+/// How much of the subprocess's combined stdout/stderr to keep as `error_message` when it fails
+/// (or exits without reporting a result), so a runaway process can't bloat the database row.
+const MAX_ERROR_MESSAGE_LEN: usize = 4000;
+
+fn manifest_dir() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The repo root, where `.claude/skills/` lives — the subprocess's cwd must be here (or a
+/// descendant) for `/budget-file-to-transaction` to resolve.
+fn repo_root() -> PathBuf {
+    manifest_dir()
+        .parent()
+        .expect("server crate is nested under the repo root")
+        .to_path_buf()
+}
+
+/// Directory a given job's uploaded file is staged in. Lives under `server/data/transactions/
+/// inputs/`, which is already gitignored for this exact purpose.
+pub fn upload_dir(job_id: Uuid) -> PathBuf {
+    manifest_dir()
+        .join("data/transactions/inputs")
+        .join(job_id.to_string())
+}
+
+/// Strips any directory components from an untrusted upload filename, keeping only the basename,
+/// so it can't be used for path traversal when staged to disk.
+pub fn sanitize_filename(name: &str) -> String {
+    Path::new(name)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("upload")
+        .to_string()
+}
+
+/// Builds the unattended `claude` invocation: no `--dangerously-skip-permissions`, instead a
+/// pre-approved allowlist scoped to reading the uploaded file and calling this server's three
+/// import-related endpoints — anything else has no TTY to prompt on, so it's denied automatically.
+fn build_command(job_id: Uuid, file_path: &Path) -> Command {
+    let upload_dir = upload_dir(job_id);
+    let prompt = format!(
+        "/budget-file-to-transaction Import the file at {} with job_id={job_id}.",
+        file_path.display()
+    );
+    // `*` right after `curl` tolerates incidental flags (e.g. `-s`) the model adds out of habit —
+    // a rigid `curl http://...` prefix broke on the first real run when it wrote `curl -s http://...`.
+    let allowed_tools = format!(
+        "Read({upload_dir}/*) \
+         Bash(curl*http://{SERVER_ADDR}/categories*) \
+         Bash(curl*-X POST*http://{SERVER_ADDR}/transactions*) \
+         Bash(curl*-X PATCH*http://{SERVER_ADDR}/transactions/import/jobs/*)",
+        upload_dir = upload_dir.display(),
+    );
+
+    let mut command = Command::new("claude");
+    command
+        .current_dir(repo_root())
+        .arg("-p")
+        .arg(prompt)
+        .arg("--tools")
+        .arg("Read,Bash")
+        .arg("--allowedTools")
+        .arg(allowed_tools)
+        .arg("--no-session-persistence")
+        .arg("--output-format")
+        .arg("text")
+        .kill_on_drop(true)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command
+}
+
+/// Truncates `text` to the last `MAX_ERROR_MESSAGE_LEN` characters, so a runaway subprocess can't
+/// bloat the stored error message.
+fn truncate_tail(text: &str) -> String {
+    let char_count = text.chars().count();
+    if char_count <= MAX_ERROR_MESSAGE_LEN {
+        text.to_string()
+    } else {
+        text.chars()
+            .skip(char_count - MAX_ERROR_MESSAGE_LEN)
+            .collect()
+    }
+}
+
+/// Runs the full unattended import: marks the job running, spawns the subprocess and waits for
+/// it, then — only if the job is still `pending`/`running` afterward, meaning the skill's own
+/// final `PATCH` never landed — marks it failed using the captured output. Always cleans up the
+/// staged upload file.
+pub async fn run_import(job_store: &JobStore, job_id: Uuid, file_path: PathBuf) {
+    job_store.mark_running(job_id);
+
+    let output = build_command(job_id, &file_path).output().await;
+
+    let fallback_error = match &output {
+        Ok(output) => {
+            let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+            combined.push_str(&String::from_utf8_lossy(&output.stderr));
+            if output.status.success() {
+                truncate_tail(&format!(
+                    "unattended import subprocess exited successfully but never reported a \
+                     result; last output:\n{combined}"
+                ))
+            } else {
+                truncate_tail(&format!(
+                    "unattended import subprocess exited with {}; last output:\n{combined}",
+                    output.status
+                ))
+            }
+        }
+        Err(e) => format!("failed to start unattended import subprocess: {e}"),
+    };
+
+    // No-op if the skill's own PATCH already moved the job to a terminal status.
+    job_store.complete(
+        job_id,
+        ImportJobStatus::Failed,
+        None,
+        None,
+        None,
+        Some(fallback_error),
+    );
+
+    if let Err(e) = tokio::fs::remove_dir_all(upload_dir(job_id)).await {
+        log::error!("failed to clean up import upload dir job_id={job_id} error={e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_filename_keeps_a_plain_name() {
+        assert_eq!(sanitize_filename("statement.csv"), "statement.csv");
+    }
+
+    #[test]
+    fn sanitize_filename_strips_directory_components() {
+        assert_eq!(sanitize_filename("../../etc/passwd"), "passwd");
+        assert_eq!(sanitize_filename("/etc/passwd"), "passwd");
+    }
+
+    #[test]
+    fn sanitize_filename_falls_back_for_empty_or_dot_only_input() {
+        assert_eq!(sanitize_filename(""), "upload");
+        assert_eq!(sanitize_filename(".."), "upload");
+    }
+
+    #[test]
+    fn truncate_tail_keeps_short_text_unchanged() {
+        assert_eq!(truncate_tail("short"), "short");
+    }
+
+    #[test]
+    fn truncate_tail_keeps_only_the_last_chars_of_long_text() {
+        let long = "a".repeat(MAX_ERROR_MESSAGE_LEN + 100);
+        let truncated = truncate_tail(&long);
+        assert_eq!(truncated.chars().count(), MAX_ERROR_MESSAGE_LEN);
+        assert!(long.ends_with(&truncated));
+    }
+}

--- a/server/src/features/transactions/import.rs
+++ b/server/src/features/transactions/import.rs
@@ -12,9 +12,7 @@ use uuid::Uuid;
 
 use super::jobs::JobStore;
 use super::model::ImportJobStatus;
-
-/// Local address the server binds to (see `main.rs`) and that the subprocess calls back into.
-const SERVER_ADDR: &str = "127.0.0.1:3055";
+use crate::shared::SERVER_ADDR;
 
 /// How much of the subprocess's combined stdout/stderr to keep as `error_message` when it fails
 /// (or exits without reporting a result), so a runaway process can't bloat the database row.
@@ -87,6 +85,28 @@ fn build_command(job_id: Uuid, file_path: &Path) -> Command {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     command
+}
+
+/// `true` if an uploaded file is worth staging: non-empty content and a non-blank filename.
+pub fn is_valid_upload(original_name: &str, file_size: u64) -> bool {
+    file_size > 0 && !original_name.trim().is_empty()
+}
+
+/// Stages an already-validated upload into `upload_dir(job_id)` under its sanitized filename,
+/// creating the directory as needed. Kept free of `JobStore`/`tokio::spawn` so it's testable on
+/// its own.
+pub async fn stage_upload(
+    job_id: Uuid,
+    original_name: &str,
+    temp_file_path: &Path,
+) -> std::io::Result<PathBuf> {
+    let dest_dir = upload_dir(job_id);
+    let dest_path = dest_dir.join(sanitize_filename(original_name));
+
+    tokio::fs::create_dir_all(&dest_dir).await?;
+    tokio::fs::copy(temp_file_path, &dest_path).await?;
+
+    Ok(dest_path)
 }
 
 /// Truncates `text` to the last `MAX_ERROR_MESSAGE_LEN` characters, so a runaway subprocess can't
@@ -164,6 +184,53 @@ mod tests {
     fn sanitize_filename_falls_back_for_empty_or_dot_only_input() {
         assert_eq!(sanitize_filename(""), "upload");
         assert_eq!(sanitize_filename(".."), "upload");
+    }
+
+    #[test]
+    fn is_valid_upload_rejects_an_empty_file() {
+        assert!(!is_valid_upload("statement.csv", 0));
+    }
+
+    #[test]
+    fn is_valid_upload_rejects_a_blank_filename() {
+        assert!(!is_valid_upload("   ", 128));
+    }
+
+    #[test]
+    fn is_valid_upload_accepts_a_real_file() {
+        assert!(is_valid_upload("statement.csv", 128));
+    }
+
+    #[tokio::test]
+    async fn stage_upload_creates_the_job_dir_and_copies_the_file() {
+        let job_id = Uuid::new_v4();
+        let src = std::env::temp_dir().join(format!("stage-upload-test-{job_id}.csv"));
+        tokio::fs::write(&src, b"date,merchant,amount\n")
+            .await
+            .unwrap();
+
+        let dest = stage_upload(job_id, "statement.csv", &src).await.unwrap();
+
+        assert_eq!(dest, upload_dir(job_id).join("statement.csv"));
+        assert_eq!(
+            tokio::fs::read(&dest).await.unwrap(),
+            b"date,merchant,amount\n"
+        );
+
+        let _ = tokio::fs::remove_file(&src).await;
+        let _ = tokio::fs::remove_dir_all(upload_dir(job_id)).await;
+    }
+
+    #[tokio::test]
+    async fn stage_upload_fails_when_the_source_file_is_missing() {
+        let job_id = Uuid::new_v4();
+        let missing_src = std::env::temp_dir().join(format!("does-not-exist-{job_id}.csv"));
+
+        assert!(stage_upload(job_id, "statement.csv", &missing_src)
+            .await
+            .is_err());
+
+        let _ = tokio::fs::remove_dir_all(upload_dir(job_id)).await;
     }
 
     #[test]

--- a/server/src/features/transactions/jobs.rs
+++ b/server/src/features/transactions/jobs.rs
@@ -1,0 +1,158 @@
+//! In-memory tracking for async budget-file import jobs (`POST /transactions/import`). Jobs are
+//! ephemeral by nature — a server restart also kills whatever `claude` subprocess was tracking
+//! them — so there's no need to persist this to Postgres alongside actual transaction data.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use super::model::{ImportJob, ImportJobStatus};
+
+#[derive(Default)]
+pub struct JobStore(Mutex<HashMap<Uuid, ImportJob>>);
+
+impl JobStore {
+    /// Creates a new job in `pending` status.
+    pub fn create(&self, file_name: String) -> ImportJob {
+        let now = Utc::now();
+        let job = ImportJob {
+            id: Uuid::new_v4(),
+            status: ImportJobStatus::Pending,
+            file_name,
+            created_count: None,
+            failed_count: None,
+            skipped_count: None,
+            error_message: None,
+            created_at: now,
+            updated_at: now,
+        };
+        self.0.lock().unwrap().insert(job.id, job.clone());
+        job
+    }
+
+    /// Fetches a job by id, or `None` if it doesn't exist (or the server has since restarted).
+    pub fn get(&self, id: Uuid) -> Option<ImportJob> {
+        self.0.lock().unwrap().get(&id).cloned()
+    }
+
+    /// Marks a job `running`. No-op if the job is unknown.
+    pub fn mark_running(&self, id: Uuid) {
+        if let Some(job) = self.0.lock().unwrap().get_mut(&id) {
+            job.status = ImportJobStatus::Running;
+            job.updated_at = Utc::now();
+        }
+    }
+
+    /// Moves a job to a terminal status (`Succeeded`/`Failed`) with its final counts/error
+    /// message. No-ops if the job is unknown or already terminal, so the unattended subprocess's
+    /// own report can't be clobbered by the server's fallback failure handler racing behind it.
+    #[allow(clippy::too_many_arguments)]
+    pub fn complete(
+        &self,
+        id: Uuid,
+        status: ImportJobStatus,
+        created_count: Option<i32>,
+        failed_count: Option<i32>,
+        skipped_count: Option<i32>,
+        error_message: Option<String>,
+    ) {
+        let mut jobs = self.0.lock().unwrap();
+        let Some(job) = jobs.get_mut(&id) else {
+            return;
+        };
+        if matches!(
+            job.status,
+            ImportJobStatus::Succeeded | ImportJobStatus::Failed
+        ) {
+            return;
+        }
+        job.status = status;
+        job.created_count = created_count;
+        job.failed_count = failed_count;
+        job.skipped_count = skipped_count;
+        job.error_message = error_message;
+        job.updated_at = Utc::now();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_returns_none_for_unknown_id() {
+        let store = JobStore::default();
+        assert!(store.get(Uuid::new_v4()).is_none());
+    }
+
+    #[test]
+    fn create_then_get_round_trips() {
+        let store = JobStore::default();
+        let job = store.create("statement.csv".to_string());
+
+        assert_eq!(job.status, ImportJobStatus::Pending);
+        assert_eq!(store.get(job.id).unwrap().status, ImportJobStatus::Pending);
+    }
+
+    #[test]
+    fn mark_running_updates_status() {
+        let store = JobStore::default();
+        let job = store.create("statement.csv".to_string());
+
+        store.mark_running(job.id);
+
+        assert_eq!(store.get(job.id).unwrap().status, ImportJobStatus::Running);
+    }
+
+    #[test]
+    fn complete_sets_terminal_status_and_counts() {
+        let store = JobStore::default();
+        let job = store.create("statement.csv".to_string());
+
+        store.complete(
+            job.id,
+            ImportJobStatus::Succeeded,
+            Some(3),
+            Some(1),
+            Some(2),
+            None,
+        );
+
+        let updated = store.get(job.id).unwrap();
+        assert_eq!(updated.status, ImportJobStatus::Succeeded);
+        assert_eq!(updated.created_count, Some(3));
+        assert_eq!(updated.failed_count, Some(1));
+        assert_eq!(updated.skipped_count, Some(2));
+    }
+
+    #[test]
+    fn complete_does_not_overwrite_a_terminal_job() {
+        let store = JobStore::default();
+        let job = store.create("statement.csv".to_string());
+        store.complete(
+            job.id,
+            ImportJobStatus::Succeeded,
+            Some(3),
+            None,
+            None,
+            None,
+        );
+
+        // The server's own fallback failure handler racing in after the skill already reported
+        // success shouldn't clobber it.
+        store.complete(
+            job.id,
+            ImportJobStatus::Failed,
+            None,
+            None,
+            None,
+            Some("subprocess exited".to_string()),
+        );
+
+        let updated = store.get(job.id).unwrap();
+        assert_eq!(updated.status, ImportJobStatus::Succeeded);
+        assert_eq!(updated.created_count, Some(3));
+    }
+}

--- a/server/src/features/transactions/mod.rs
+++ b/server/src/features/transactions/mod.rs
@@ -1,8 +1,11 @@
 mod download;
 mod handlers;
+mod import;
+mod jobs;
 mod model;
 mod repository;
 #[cfg(test)]
 mod tests;
 
 pub use handlers::configure;
+pub use jobs::JobStore;

--- a/server/src/features/transactions/model.rs
+++ b/server/src/features/transactions/model.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use uuid::Uuid;
 
 /// A single row in the `transactions` table, joined with its category.
 #[derive(Debug, Serialize, FromRow)]
@@ -15,10 +16,12 @@ pub struct Transaction {
     pub category_name_fr: String,
     pub category_type: String,
     pub account: String,
+    pub reviewed: bool,
     pub created_at: DateTime<Utc>,
 }
 
-/// Body for `POST /transactions`. All fields are required; `id` and `created_at` are generated.
+/// Body for `POST /transactions`. `id` and `created_at` are generated. `reviewed` defaults to
+/// `true` when absent; automated imports set it to `false` so they can be found later.
 #[derive(Debug, Deserialize)]
 pub struct NewTransaction {
     pub date: NaiveDate,
@@ -26,6 +29,44 @@ pub struct NewTransaction {
     pub amount: Decimal,
     pub category_id: i32,
     pub account: String,
+    pub reviewed: Option<bool>,
+}
+
+/// In-memory status of an async budget-file import, tracked for as long as this server process
+/// runs — a job doesn't need to survive a restart, since a restart also kills the subprocess
+/// tracking it.
+#[derive(Debug, Clone, Serialize)]
+pub struct ImportJob {
+    pub id: Uuid,
+    pub status: ImportJobStatus,
+    pub file_name: String,
+    pub created_count: Option<i32>,
+    pub failed_count: Option<i32>,
+    pub skipped_count: Option<i32>,
+    pub error_message: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Status of an [`ImportJob`]. `Succeeded`/`Failed` are terminal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportJobStatus {
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+}
+
+/// Body for `PATCH /transactions/import/jobs/{id}` — how the unattended import subprocess itself
+/// reports its final result back to the server.
+#[derive(Debug, Deserialize)]
+pub struct ImportJobReport {
+    pub status: ImportJobStatus,
+    pub created_count: Option<i32>,
+    pub failed_count: Option<i32>,
+    pub skipped_count: Option<i32>,
+    pub error_message: Option<String>,
 }
 
 /// Optional query params for `GET /transactions`. Absent fields mean "no filter".

--- a/server/src/features/transactions/repository.rs
+++ b/server/src/features/transactions/repository.rs
@@ -5,7 +5,7 @@ use super::model::{NewTransaction, SortOrder, Transaction, TransactionFilter, Tr
 const SELECT_COLUMNS: &str = "
     t.id, t.date, t.merchant, t.amount, t.category_id,
     c.name_en AS category_name_en, c.name_fr AS category_name_fr, c.type AS category_type,
-    t.account, t.created_at";
+    t.account, t.reviewed, t.created_at";
 
 const FROM_JOIN: &str = "FROM transactions t JOIN categories c ON c.id = t.category_id";
 
@@ -25,8 +25,8 @@ pub async fn create(
 ) -> Result<Transaction, sqlx::Error> {
     sqlx::query_as::<_, Transaction>(&format!(
         "WITH inserted AS (
-            INSERT INTO transactions (date, merchant, amount, category_id, account)
-            VALUES ($1, $2, $3, $4, $5)
+            INSERT INTO transactions (date, merchant, amount, category_id, account, reviewed)
+            VALUES ($1, $2, $3, $4, $5, $6)
             RETURNING *
          )
          SELECT {SELECT_COLUMNS}
@@ -37,6 +37,7 @@ pub async fn create(
     .bind(new_transaction.amount)
     .bind(new_transaction.category_id)
     .bind(&new_transaction.account)
+    .bind(new_transaction.reviewed.unwrap_or(true))
     .fetch_one(pool)
     .await
 }

--- a/server/src/features/transactions/tests.rs
+++ b/server/src/features/transactions/tests.rs
@@ -962,6 +962,38 @@ async fn delete_transaction_removes_row(pool: PgPool) {
     assert_eq!(get_resp.status(), 404);
 }
 
+// --- POST /transactions/import ---
+//
+// Only the size-limit rejection is tested here: it's rejected during multipart extraction, before
+// `import_transactions` ever runs, so — unlike a real successful upload — it never spawns a
+// `claude` subprocess.
+
+#[sqlx::test]
+async fn import_transactions_rejects_a_file_over_the_size_limit(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+
+    let oversized = vec![b'a'; 11 * 1024 * 1024]; // over the 10 MB field limit
+    let (body, headers) = actix_multipart::test::create_form_data_payload_and_headers(
+        "file",
+        Some("statement.csv".to_string()),
+        None,
+        web::Bytes::from(oversized),
+    );
+
+    let mut req = test::TestRequest::post().uri("/transactions/import");
+    for (name, value) in headers.iter() {
+        req = req.insert_header((name.clone(), value.clone()));
+    }
+    let resp = test::call_service(&app, req.set_payload(body).to_request()).await;
+
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    // Pins down the specific message, not just "some JSON error" — the field-level size limit
+    // surfaces as `MultipartError::Payload(PayloadError::Overflow)`, easy to mis-map to the wrong
+    // Fluent key (as a first pass here did) since it isn't `MultipartError::Field`.
+    assert!(body["error"].as_str().unwrap().contains("too large"));
+}
+
 // --- /transactions/import/jobs/{id} ---
 //
 // These test the HTTP wiring for the in-memory JobStore directly (seeding a job via

--- a/server/src/features/transactions/tests.rs
+++ b/server/src/features/transactions/tests.rs
@@ -10,6 +10,7 @@ use actix_web::{test, web, App};
 use sqlx::PgPool;
 
 use super::handlers::configure;
+use super::jobs::JobStore;
 use crate::shared::l10n::L10n;
 
 fn app_with(
@@ -23,9 +24,28 @@ fn app_with(
         InitError = (),
     >,
 > {
+    app_with_jobs(pool, web::Data::new(JobStore::default()))
+}
+
+/// Like `app_with`, but takes an externally-owned `JobStore` so a test can seed a job directly
+/// (via `JobStore::create`) without going through `POST /transactions/import`, which would spawn
+/// a real `claude` subprocess.
+fn app_with_jobs(
+    pool: PgPool,
+    job_store: web::Data<JobStore>,
+) -> App<
+    impl actix_web::dev::ServiceFactory<
+        actix_web::dev::ServiceRequest,
+        Config = (),
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
+> {
     App::new()
         .app_data(web::Data::new(pool))
         .app_data(web::Data::new(L10n::new()))
+        .app_data(job_store)
         .configure(configure)
 }
 
@@ -747,6 +767,47 @@ async fn create_transaction_persists_all_fields(pool: PgPool) {
 }
 
 #[sqlx::test]
+async fn create_transaction_defaults_reviewed_to_true(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    let req = test::TestRequest::post()
+        .uri("/transactions")
+        .set_json(serde_json::json!({
+            "date": "2024-01-15",
+            "merchant": "STARBUCKS",
+            "amount": "12.34",
+            "category_id": 1,
+            "account": "User 1",
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 201);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body["reviewed"], true);
+}
+
+#[sqlx::test]
+async fn create_transaction_respects_explicit_reviewed_false(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+    let req = test::TestRequest::post()
+        .uri("/transactions")
+        .set_json(serde_json::json!({
+            "date": "2024-01-15",
+            "merchant": "STARBUCKS",
+            "amount": "12.34",
+            "category_id": 1,
+            "account": "User 1",
+            "reviewed": false,
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 201);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body["reviewed"], false);
+}
+
+#[sqlx::test]
 async fn create_transaction_rejects_unknown_category_id(pool: PgPool) {
     let app = test::init_service(app_with(pool)).await;
     let req = test::TestRequest::post()
@@ -899,6 +960,74 @@ async fn delete_transaction_removes_row(pool: PgPool) {
         .to_request();
     let get_resp = test::call_service(&app, get_req).await;
     assert_eq!(get_resp.status(), 404);
+}
+
+// --- /transactions/import/jobs/{id} ---
+//
+// These test the HTTP wiring for the in-memory JobStore directly (seeding a job via
+// `JobStore::create`), never through `POST /transactions/import` — that endpoint spawns a real
+// `claude` subprocess, which has no place in an automated test suite.
+
+#[sqlx::test]
+async fn get_import_job_returns_404_for_unknown_id(pool: PgPool) {
+    let app = test::init_service(app_with(pool)).await;
+
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/transactions/import/jobs/{}",
+            uuid::Uuid::new_v4()
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 404);
+}
+
+#[sqlx::test]
+async fn get_import_job_returns_a_freshly_created_job_as_pending(pool: PgPool) {
+    let job_store = web::Data::new(JobStore::default());
+    let job = job_store.create("statement.csv".to_string());
+    let app = test::init_service(app_with_jobs(pool, job_store)).await;
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/transactions/import/jobs/{}", job.id))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body["status"], "pending");
+    assert_eq!(body["file_name"], "statement.csv");
+}
+
+#[sqlx::test]
+async fn report_import_job_updates_status_and_get_reflects_it(pool: PgPool) {
+    let job_store = web::Data::new(JobStore::default());
+    let job = job_store.create("statement.csv".to_string());
+    let app = test::init_service(app_with_jobs(pool, job_store)).await;
+
+    let patch_req = test::TestRequest::patch()
+        .uri(&format!("/transactions/import/jobs/{}", job.id))
+        .set_json(serde_json::json!({
+            "status": "succeeded",
+            "created_count": 3,
+            "failed_count": 0,
+            "skipped_count": 1,
+        }))
+        .to_request();
+    let patch_resp = test::call_service(&app, patch_req).await;
+    assert_eq!(patch_resp.status(), 204);
+
+    let get_req = test::TestRequest::get()
+        .uri(&format!("/transactions/import/jobs/{}", job.id))
+        .to_request();
+    let get_resp = test::call_service(&app, get_req).await;
+
+    assert_eq!(get_resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(get_resp).await;
+    assert_eq!(body["status"], "succeeded");
+    assert_eq!(body["created_count"], 3);
+    assert_eq!(body["skipped_count"], 1);
 }
 
 #[sqlx::test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -6,6 +6,7 @@ use actix_web::{web, App, HttpServer};
 
 use crate::features::transactions::JobStore;
 use crate::shared::l10n::L10n;
+use crate::shared::SERVER_ADDR;
 
 /// Main function to start the server
 #[actix_web::main]
@@ -13,7 +14,7 @@ async fn main() -> std::io::Result<()> {
     dotenvy::dotenv().ok();
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 
-    let addr = "127.0.0.1:3055";
+    let addr = SERVER_ADDR;
     println!("Server listening on http://{addr}/transactions            (GET list, optional ?date=&merchant=; POST create)");
     println!("  and http://{addr}/transactions/{{id}}        (GET, PATCH, DELETE)");
     println!("  and http://{addr}/categories               (GET list; POST create)");

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -4,6 +4,7 @@ mod shared;
 use actix_cors::Cors;
 use actix_web::{web, App, HttpServer};
 
+use crate::features::transactions::JobStore;
 use crate::shared::l10n::L10n;
 
 /// Main function to start the server
@@ -20,6 +21,7 @@ async fn main() -> std::io::Result<()> {
 
     let l10n = web::Data::new(L10n::new());
     let pool = web::Data::new(shared::postgres::create_pool().await);
+    let import_jobs = web::Data::new(JobStore::default());
 
     // Actix web server configuration
     HttpServer::new(move || {
@@ -36,6 +38,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(cors)
             .app_data(l10n.clone())
             .app_data(pool.clone())
+            .app_data(import_jobs.clone())
             .configure(features::transactions::configure)
             .configure(features::categories::configure)
     })

--- a/server/src/shared/mod.rs
+++ b/server/src/shared/mod.rs
@@ -1,3 +1,7 @@
 pub mod http_error;
 pub mod l10n;
 pub mod postgres;
+
+/// Address this server binds to (`main.rs`) and that the unattended import subprocess calls back
+/// into (`features::transactions::import`) — a single source of truth so the two can't drift.
+pub const SERVER_ADDR: &str = "127.0.0.1:3055";


### PR DESCRIPTION
Wires the placeholder Import button to POST /transactions/import, which stages the uploaded file and runs the budget-file-to-transaction skill unattended (no --dangerously-skip-permissions; a scoped --allowedTools allowlist covers only reading the upload and calling this server's categories/transactions/import-job endpoints). Job status is tracked in-memory and polled from the client; imported rows are flagged reviewed = false for later review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous budget-file transaction imports with upload, progress tracking, and completion status.
  * Added import controls to the Transactions screen with start, success, and failure notifications.
  * Added support for tracking whether transactions have been reviewed.
  * Imported transactions are marked as unreviewed by default.

* **Bug Fixes**
  * Added validation and localized messages for missing files, missing jobs, and uploads exceeding 10 MB.
  * Added success styling for import notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->