### PR TITLE
Add transaction modal to transactions page

### DIFF
--- a/client/src/features/transactions/AddTransactionModal.css
+++ b/client/src/features/transactions/AddTransactionModal.css
@@ -92,6 +92,35 @@
 
 .modal-body select {
   cursor: pointer;
+  padding-right: 34px;
+}
+
+.modal-body input[type='date']::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+}
+
+.amount-input-wrapper {
+  position: relative;
+}
+
+.amount-prefix {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #999;
+  font-size: 15px;
+  pointer-events: none;
+}
+
+.amount-input-wrapper input {
+  padding-left: 26px;
+}
+
+.modal-error {
+  margin: -6px 0 0;
+  color: #ff6b6b;
+  font-size: 13px;
 }
 
 .modal-footer {

--- a/client/src/features/transactions/AddTransactionModal.css
+++ b/client/src/features/transactions/AddTransactionModal.css
@@ -92,7 +92,14 @@
 
 .modal-body select {
   cursor: pointer;
-  padding-right: 34px;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding-right: 40px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%23999999' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 12px 8px;
 }
 
 .modal-body input[type='date']::-webkit-calendar-picker-indicator {

--- a/client/src/features/transactions/AddTransactionModal.css
+++ b/client/src/features/transactions/AddTransactionModal.css
@@ -1,0 +1,125 @@
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+}
+
+.add-transaction-modal {
+  width: 420px;
+  max-width: 90vw;
+  background: #2f2f2f;
+  color: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  font-family: inherit;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 18px 22px;
+  border-bottom: 1px solid #444;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  color: #bbb;
+  font-size: 26px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: #fff;
+}
+
+.modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px 22px;
+}
+
+.modal-body label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #f1f1f1;
+  margin-bottom: -6px;
+}
+
+.modal-body input,
+.modal-body select {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 11px 14px;
+  border: 1px solid #555;
+  border-radius: 8px;
+  background: #1f1f1f;
+  color: #fff;
+  font-size: 15px;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.modal-body input::placeholder {
+  color: #999;
+}
+
+.modal-body input:focus,
+.modal-body select:focus {
+  border-color: #ff7a30;
+}
+
+.modal-body select {
+  cursor: pointer;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 18px 22px;
+  border-top: 1px solid #444;
+}
+
+.modal-button {
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.modal-button--cancel {
+  background: transparent;
+  color: #fff;
+  border: 1px solid #666;
+}
+
+.modal-button--cancel:hover {
+  background: #444;
+}
+
+.modal-button--primary {
+  background: #ff7a30;
+  border: none;
+  color: #fff;
+}
+
+.modal-button--primary:hover {
+  background: #ff8d4f;
+}

--- a/client/src/features/transactions/AddTransactionModal.css
+++ b/client/src/features/transactions/AddTransactionModal.css
@@ -17,8 +17,8 @@
   max-height: calc(100dvh - 2rem);
   display: flex;
   flex-direction: column;
-  background: #2f2f2f;
-  color: #fff;
+  background: var(--color-dark);
+  color: var(--color-white);
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
@@ -29,7 +29,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 18px 22px;
-  border-bottom: 1px solid #444;
+  border-bottom: 1px solid var(--color-medium);
 }
 
 .modal-header h2 {
@@ -41,14 +41,14 @@
 .modal-close {
   background: transparent;
   border: none;
-  color: #bbb;
+  color: var(--color-lightest);
   font-size: 26px;
   cursor: pointer;
   line-height: 1;
 }
 
 .modal-close:hover {
-  color: #fff;
+  color: var(--color-white);
 }
 
 .modal-body {
@@ -63,7 +63,7 @@
 .modal-body label {
   font-size: 14px;
   font-weight: 600;
-  color: #f1f1f1;
+  color: var(--color-white);
   margin-bottom: -6px;
 }
 
@@ -72,22 +72,26 @@
   width: 100%;
   box-sizing: border-box;
   padding: 11px 14px;
-  border: 1px solid #555;
+  border: 1px solid var(--color-medium);
   border-radius: 8px;
-  background: #1f1f1f;
-  color: #fff;
+  background: var(--color-background);
+  color: var(--color-white);
   font-size: 15px;
   outline: none;
   transition: border-color 0.2s ease;
 }
 
 .modal-body input::placeholder {
-  color: #999;
+  color: var(--color-lightest);
 }
 
 .modal-body input:focus,
 .modal-body select:focus {
-  border-color: #ff7a30;
+  border-color: var(--color-primary);
+}
+
+.category-select-wrapper {
+  position: relative;
 }
 
 .modal-body select {
@@ -96,10 +100,16 @@
   -webkit-appearance: none;
   -moz-appearance: none;
   padding-right: 40px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%23999999' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 14px center;
-  background-size: 12px 8px;
+}
+
+.category-select-arrow {
+  position: absolute;
+  right: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-lightest);
+  font-size: 12px;
+  pointer-events: none;
 }
 
 .modal-body input[type='date']::-webkit-calendar-picker-indicator {
@@ -115,7 +125,7 @@
   left: 14px;
   top: 50%;
   transform: translateY(-50%);
-  color: #999;
+  color: var(--color-lightest);
   font-size: 15px;
   pointer-events: none;
 }
@@ -126,7 +136,7 @@
 
 .modal-error {
   margin: -6px 0 0;
-  color: #ff6b6b;
+  color: var(--color-error);
   font-size: 13px;
 }
 
@@ -135,7 +145,7 @@
   justify-content: flex-end;
   gap: 10px;
   padding: 18px 22px;
-  border-top: 1px solid #444;
+  border-top: 1px solid var(--color-medium);
 }
 
 .modal-button {
@@ -149,20 +159,20 @@
 
 .modal-button--cancel {
   background: transparent;
-  color: #fff;
-  border: 1px solid #666;
+  color: var(--color-white);
+  border: 1px solid var(--color-light);
 }
 
 .modal-button--cancel:hover {
-  background: #444;
+  background: var(--color-medium);
 }
 
 .modal-button--primary {
-  background: #ff7a30;
+  background: var(--color-primary);
   border: none;
-  color: #fff;
+  color: var(--color-white);
 }
 
 .modal-button--primary:hover {
-  background: #ff8d4f;
+  filter: brightness(1.2);
 }

--- a/client/src/features/transactions/AddTransactionModal.css
+++ b/client/src/features/transactions/AddTransactionModal.css
@@ -6,17 +6,22 @@
   justify-content: center;
   align-items: center;
   z-index: 999;
+
+  overflow-y: auto;
+  padding: 1rem;
 }
 
 .add-transaction-modal {
   width: 420px;
   max-width: 90vw;
+  max-height: calc(100dvh - 2rem);
+  display: flex;
+  flex-direction: column;
   background: #2f2f2f;
   color: #fff;
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
-  font-family: inherit;
 }
 
 .modal-header {
@@ -50,6 +55,8 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+  padding: 20px 22px;
+  overflow-y: auto;
   padding: 20px 22px;
 }
 

--- a/client/src/features/transactions/AddTransactionModal.tsx
+++ b/client/src/features/transactions/AddTransactionModal.tsx
@@ -8,10 +8,10 @@ type AddTransactionModalProps = {
   onClose: () => void;
 };
 
-export function AddTransactionModal({
+export const AddTransactionModal = ({
   open,
   onClose,
-}: AddTransactionModalProps) {
+}: AddTransactionModalProps) => {
   const { t, i18n } = useTranslation();
   const { data: categories } = useCategories();
   const [amount, setAmount] = useState('');
@@ -124,4 +124,4 @@ export function AddTransactionModal({
       </div>
     </div>
   );
-}
+};

--- a/client/src/features/transactions/AddTransactionModal.tsx
+++ b/client/src/features/transactions/AddTransactionModal.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import { useCategories } from '../categories/use-categories';
 import { notImplementedToast } from '../../lib/toast';
 import './AddTransactionModal.css';
@@ -163,21 +165,29 @@ export const AddTransactionModal = ({
           <label htmlFor="category">
             {t('transactions.add.category', 'Category')}
           </label>
-          <select
-            id="category"
-            value={category}
-            onChange={handleCategoryChange}
-          >
-            <option value="">
-              {t('transactions.add.selectCategory', 'Select a category')}
-            </option>
-
-            {categories?.map((category) => (
-              <option key={category.id} value={category.id}>
-                {i18n.language === 'fr' ? category.name_fr : category.name_en}
+          <div className="category-select-wrapper">
+            <select
+              id="category"
+              value={category}
+              onChange={handleCategoryChange}
+            >
+              <option value="">
+                {t('transactions.add.selectCategory', 'Select a category')}
               </option>
-            ))}
-          </select>
+
+              {categories?.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {i18n.language === 'fr'
+                    ? category.name_fr
+                    : category.name_en}
+                </option>
+              ))}
+            </select>
+            <FontAwesomeIcon
+              icon={faChevronDown}
+              className="category-select-arrow"
+            />
+          </div>
 
           {error && (
             <p className="modal-error" role="alert">

--- a/client/src/features/transactions/AddTransactionModal.tsx
+++ b/client/src/features/transactions/AddTransactionModal.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCategories } from '../categories/use-categories';
 import './AddTransactionModal.css';
@@ -7,6 +8,9 @@ type AddTransactionModalProps = {
   open: boolean;
   onClose: () => void;
 };
+
+const FOCUSABLE_SELECTOR =
+  'input, select, button, [href], [tabindex]:not([tabindex="-1"])';
 
 export const AddTransactionModal = ({
   open,
@@ -18,10 +22,71 @@ export const AddTransactionModal = ({
   const [merchant, setMerchant] = useState('');
   const [date, setDate] = useState('');
   const [category, setCategory] = useState('');
+  const [error, setError] = useState('');
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+      FOCUSABLE_SELECTOR,
+    );
+    focusable?.[0]?.focus();
+  }, [open]);
 
   if (!open) return null;
 
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      onClose();
+      return;
+    }
+
+    if (e.key !== 'Tab') return;
+
+    const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+      FOCUSABLE_SELECTOR,
+    );
+    if (!focusable || focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+
+  const handleAmountChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setError('');
+    setAmount(e.target.value.replace(/[^0-9.,]/g, ''));
+  };
+
+  const handleMerchantChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setError('');
+    setMerchant(e.target.value);
+  };
+
+  const handleDateChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setError('');
+    setDate(e.target.value);
+  };
+
+  const handleCategoryChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    setError('');
+    setCategory(e.target.value);
+  };
+
   const handleSubmit = () => {
+    if (!amount.trim() || !merchant.trim() || !date.trim() || !category.trim()) {
+      setError(t('transactions.add.required', 'All fields are required.'));
+      return;
+    }
+
     // API integration will be added in a later issue.
     console.log({
       amount,
@@ -35,15 +100,24 @@ export const AddTransactionModal = ({
 
   return (
     <div className="modal-overlay">
-      <div className="add-transaction-modal">
+      <div
+        ref={dialogRef}
+        className="add-transaction-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-transaction-title"
+        onKeyDown={handleKeyDown}
+      >
         <div className="modal-header">
-          <h2>{t('transactions.add.title', 'Add transaction')}</h2>
+          <h2 id="add-transaction-title">
+            {t('transactions.add.title', 'Add transaction')}
+          </h2>
 
           <button
             type="button"
             className="modal-close"
             onClick={onClose}
-            aria-label="Close"
+            aria-label={t('transactions.add.close', 'Close')}
           >
             ×
           </button>
@@ -53,24 +127,32 @@ export const AddTransactionModal = ({
           <label htmlFor="amount">
             {t('transactions.add.amount', 'Amount')}
           </label>
-          <input
-            id="amount"
-            type="number"
-            min="0"
-            step="0.01"
-            placeholder="$0.00"
-            value={amount}
-            onChange={(e) => setAmount(e.target.value)}
-/>
-          <label htmlFor="merchant ">
+          <div className="amount-input-wrapper">
+            <span className="amount-prefix" aria-hidden="true">
+              $
+            </span>
+            <input
+              id="amount"
+              type="text"
+              inputMode="decimal"
+              placeholder="0.00"
+              value={amount}
+              onChange={handleAmountChange}
+            />
+          </div>
+
+          <label htmlFor="merchant">
             {t('transactions.add.merchant', 'Merchant')}
           </label>
           <input
             id="merchant"
             type="text"
-            placeholder="Merchant Name"
+            placeholder={t(
+              'transactions.add.merchantPlaceholder',
+              'Merchant Name',
+            )}
             value={merchant}
-            onChange={(e) => setMerchant(e.target.value)}
+            onChange={handleMerchantChange}
           />
 
           <label htmlFor="date">
@@ -80,7 +162,7 @@ export const AddTransactionModal = ({
             id="date"
             type="date"
             value={date}
-            onChange={(e) => setDate(e.target.value)}
+            onChange={handleDateChange}
           />
 
           <label htmlFor="category">
@@ -89,19 +171,24 @@ export const AddTransactionModal = ({
           <select
             id="category"
             value={category}
-            onChange={(e) => setCategory(e.target.value)}
+            onChange={handleCategoryChange}
           >
             <option value="">
               {t('transactions.add.selectCategory', 'Select a category')}
             </option>
 
             {categories?.map((category) => (
-            <option key={category.id} value={category.id}>
-            {i18n.language === 'fr' ? category.name_fr : category.name_en}
-            
-            </option>
+              <option key={category.id} value={category.id}>
+                {i18n.language === 'fr' ? category.name_fr : category.name_en}
+              </option>
             ))}
           </select>
+
+          {error && (
+            <p className="modal-error" role="alert">
+              {error}
+            </p>
+          )}
         </div>
 
         <div className="modal-footer">
@@ -110,7 +197,7 @@ export const AddTransactionModal = ({
             className="modal-button modal-button--cancel"
             onClick={onClose}
           >
-            {t('common.cancel', 'Cancel')}
+            {t('transactions.add.cancel', 'Cancel')}
           </button>
 
           <button

--- a/client/src/features/transactions/AddTransactionModal.tsx
+++ b/client/src/features/transactions/AddTransactionModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCategories } from '../categories/use-categories';
+import { notImplementedToast } from '../../lib/toast';
 import './AddTransactionModal.css';
 
 type AddTransactionModalProps = {
@@ -88,13 +89,7 @@ export const AddTransactionModal = ({
     }
 
     // API integration will be added in a later issue.
-    console.log({
-      amount,
-      merchant,
-      date,
-      category,
-    });
-
+    notImplementedToast();
     onClose();
   };
 

--- a/client/src/features/transactions/AddTransactionModal.tsx
+++ b/client/src/features/transactions/AddTransactionModal.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useCategories } from '../categories/use-categories';
+import './AddTransactionModal.css';
+
+type AddTransactionModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function AddTransactionModal({
+  open,
+  onClose,
+}: AddTransactionModalProps) {
+  const { t, i18n } = useTranslation();
+  const { data: categories } = useCategories();
+  const [amount, setAmount] = useState('');
+  const [merchant, setMerchant] = useState('');
+  const [date, setDate] = useState('');
+  const [category, setCategory] = useState('');
+
+  if (!open) return null;
+
+  const handleSubmit = () => {
+    // API integration will be added in a later issue.
+    console.log({
+      amount,
+      merchant,
+      date,
+      category,
+    });
+
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="add-transaction-modal">
+        <div className="modal-header">
+          <h2>{t('transactions.add.title', 'Add transaction')}</h2>
+
+          <button
+            type="button"
+            className="modal-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <label htmlFor="amount">
+            {t('transactions.add.amount', 'Amount')}
+          </label>
+          <input
+            id="amount"
+            type="number"
+            min="0"
+            step="0.01"
+            placeholder="$0.00"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+/>
+          <label htmlFor="merchant ">
+            {t('transactions.add.merchant', 'Merchant')}
+          </label>
+          <input
+            id="merchant"
+            type="text"
+            placeholder="Merchant Name"
+            value={merchant}
+            onChange={(e) => setMerchant(e.target.value)}
+          />
+
+          <label htmlFor="date">
+            {t('transactions.add.date', 'Date')}
+          </label>
+          <input
+            id="date"
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+
+          <label htmlFor="category">
+            {t('transactions.add.category', 'Category')}
+          </label>
+          <select
+            id="category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            <option value="">
+              {t('transactions.add.selectCategory', 'Select a category')}
+            </option>
+
+            {categories?.map((category) => (
+            <option key={category.id} value={category.id}>
+            {i18n.language === 'fr' ? category.name_fr : category.name_en}
+            
+            </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="modal-footer">
+          <button
+            type="button"
+            className="modal-button modal-button--cancel"
+            onClick={onClose}
+          >
+            {t('common.cancel', 'Cancel')}
+          </button>
+
+          <button
+            type="button"
+            className="modal-button modal-button--primary"
+            onClick={handleSubmit}
+          >
+            {t('transactions.add.submit', 'Add transaction')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -63,6 +63,17 @@ export const en = {
       filters: 'Filters',
       add: 'Add',
     },
+
+  add: {
+    title: 'Add transaction',
+    amount: 'Amount',
+    merchant: 'Merchant',
+    date: 'Date',
+    category: 'Category',
+    submit: 'Add transaction',
+    selectCategory: 'Select category',
+  },
+
     toolbar: {
       allTransactions: 'All transactions',
       editMultiple: 'Edit multiple',

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -68,10 +68,14 @@ export const en = {
     title: 'Add transaction',
     amount: 'Amount',
     merchant: 'Merchant',
+    merchantPlaceholder: 'Merchant Name',
     date: 'Date',
     category: 'Category',
     submit: 'Add transaction',
     selectCategory: 'Select category',
+    cancel: 'Cancel',
+    close: 'Close',
+    required: 'All fields are required.',
   },
 
     toolbar: {

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -65,6 +65,17 @@ export const fr: typeof en = {
       filters: 'Filtres',
       add: 'Ajouter',
     },
+  
+  add: {
+    title: 'Ajouter une transaction',
+    amount: 'Montant',
+    merchant: 'Commerçant',
+    date: 'Date',
+    category: 'Catégorie',
+    selectCategory: 'Sélectionnez une catégorie',
+    submit: 'Ajouter la transaction',
+  },
+
     toolbar: {
       allTransactions: 'Toutes les transactions',
       editMultiple: 'Modifier plusieurs',

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -70,10 +70,14 @@ export const fr: typeof en = {
     title: 'Ajouter une transaction',
     amount: 'Montant',
     merchant: 'Commerçant',
+    merchantPlaceholder: 'Nom du commerçant',
     date: 'Date',
     category: 'Catégorie',
     selectCategory: 'Sélectionnez une catégorie',
     submit: 'Ajouter la transaction',
+    cancel: 'Annuler',
+    close: 'Fermer',
+    required: 'Tous les champs sont obligatoires.',
   },
 
     toolbar: {

--- a/client/src/routes/_app.transactions.tsx
+++ b/client/src/routes/_app.transactions.tsx
@@ -11,7 +11,8 @@ import { ImportButton } from '../features/transactions/ImportButton';
 import { notImplementedToast } from '../lib/toast';
 import type { SortOrder } from '../features/transactions/types';
 import '../components/TopMenu.css';
-
+import { useState } from 'react';
+import { AddTransactionModal } from '../features/transactions/AddTransactionModal';
 type TransactionsSearch = {
   search?: string;
   order?: SortOrder;
@@ -51,24 +52,33 @@ const ClearAllButton = () => {
 
 const TransactionsTopMenuActions = () => {
   const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
 
   return (
     <>
       <ClearAllButton />
       <SearchButton />
       <DateRangeButton />
+
       <TopMenuButton
         icon={faFilter}
         label={t('transactions.topMenu.filters')}
         onClick={notImplementedToast}
       />
+
       <ImportButton />
       <DownloadButton />
+
       <TopMenuButton
         icon={faPlus}
         label={t('transactions.topMenu.add')}
         variant="primary"
-        onClick={notImplementedToast}
+        onClick={() => setOpen(true)}
+      />
+
+      <AddTransactionModal
+        open={open}
+        onClose={() => setOpen(false)}
       />
     </>
   );

--- a/client/src/routes/_app.transactions.tsx
+++ b/client/src/routes/_app.transactions.tsx
@@ -11,7 +11,7 @@ import { ImportButton } from '../features/transactions/ImportButton';
 import { notImplementedToast } from '../lib/toast';
 import type { SortOrder } from '../features/transactions/types';
 import '../components/TopMenu.css';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { AddTransactionModal } from '../features/transactions/AddTransactionModal';
 type TransactionsSearch = {
   search?: string;
@@ -53,6 +53,7 @@ const ClearAllButton = () => {
 const TransactionsTopMenuActions = () => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const addButtonRef = useRef<HTMLButtonElement>(null);
 
   return (
     <>
@@ -70,15 +71,21 @@ const TransactionsTopMenuActions = () => {
       <DownloadButton />
 
       <TopMenuButton
+        ref={addButtonRef}
         icon={faPlus}
         label={t('transactions.topMenu.add')}
         variant="primary"
+        aria-haspopup="dialog"
+        aria-expanded={open}
         onClick={() => setOpen(true)}
       />
 
       <AddTransactionModal
         open={open}
-        onClose={() => setOpen(false)}
+        onClose={() => {
+          setOpen(false);
+          addButtonRef.current?.focus();
+        }}
       />
     </>
   );


### PR DESCRIPTION
## Summary

- Added the "Add transaction" action to the Transactions page.
- Implemented the Add Transaction modal.
- Added Amount, Merchant, Date, and Category fields.
- Added English and French translations for the modal.
- Styled the modal to match the provided mockup.

## Notes

- The category dropdown uses the existing `useCategories()` hook.
- On my local setup, populating the dropdown depends on the frontend API configuration (`VITE_API_BASE_URL`) and a running backend. @samuel-duhaime 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Add transaction” modal with amount, merchant, date, and category fields.
  * Added localized English and French labels, placeholders, and actions.
  * Added close and cancel controls for dismissing the modal.
  * Added required-field validation and inline error messages.
  * Added currency formatting support for amount entry.
* **Accessibility**
  * Added keyboard focus management, Escape-to-close, Tab navigation, and dialog semantics.
  * Restores focus to the menu button after closing.
* **Style**
  * Improved modal scrolling, responsive sizing, select controls, and date picker interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->