### PR TITLE
Docs: Document client setup, import CLI dependency, and undocumented endpoints in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,47 @@
 - [How to run](#how-to-run)
 - [API](#api)
 - [Tests](#tests)
+- [Lint & Format](#lint--format)
 - [License](#license)
 
 ## Install
 
+### Server
+
 1. **Rust** — Install the stable toolchain with [rustup](https://rustup.rs/) so you have `cargo` on your PATH.
-2. **PostgreSQL** — Install it and have a server running locally (e.g. `sudo apt install postgresql`. Create a database for this project (any name, matched to `DATABASE_URL` below).
+2. **PostgreSQL** — Install it and have a server running locally (e.g. `sudo apt install postgresql`). Then create a database for this project (any name, matched to `DATABASE_URL` below), e.g.:
+
+   ```bash
+   psql -h localhost -U postgres -W -c 'CREATE DATABASE "firebird-money";'
+   ```
+
+   You'll be prompted for the `postgres` user's password — use that same password in `DATABASE_URL` in `.env` below.
+
+   Migrations create the tables automatically on startup, but they don't create the database itself — skipping this step fails with `database "firebird-money" does not exist`.
 3. **cargo-watch** (used by the VS Code "Run Server" task for auto-reload on save) — `cargo install cargo-watch`.
-4. **This repo** — Clone it (or download it), then from the repo root:
+4. **[Claude Code](https://claude.com/product/claude-code)**, logged in — `POST /transactions/import` shells out to a `claude` subprocess (running the `budget-file-to-transaction` skill) to turn an uploaded budget file into transactions. `claude` must be on your `PATH` and authenticated, or every import job will fail.
+5. **This repo** — Clone it (or download it), then from the repo root:
 
-```bash
-cd server
-cargo build
-```
+   ```bash
+   cd server
+   cargo build
+   ```
 
-The first `cargo build` (or `cargo run`) downloads dependencies and compiles the server.
+   The first `cargo build` (or `cargo run`) downloads dependencies and compiles the server.
+
+### Client
+
+1. **Node.js** — Install a recent LTS version (includes `npm`).
+2. **This repo** — Clone it (or download it), then from the repo root:
+
+   ```bash
+   cd client
+   npm install
+   ```
 
 ## Configuration
+
+### Server
 
 Copy the example environment file into place, then edit it with your own Postgres credentials:
 
@@ -36,7 +60,22 @@ cp .env.example .env
 
 `DATABASE_URL` must point at a reachable Postgres database, e.g. `postgres://user:password@localhost:5432/firebird-money`. The schema is created automatically: every `cargo run` applies any pending migrations from `server/migrations/` on startup.
 
+`DEFAULT_LANGUAGE` sets the server's response locale — `"en"` or `"fr"`. Unset or invalid falls back to English.
+
+### Client
+
+Copy the example environment file into place:
+
+```bash
+cd client
+cp .env.example .env
+```
+
+`VITE_API_BASE_URL` must point at the running server, e.g. `http://localhost:3055`.
+
 ## How to run
+
+### Server
 
 ```bash
 cd server
@@ -45,17 +84,33 @@ cargo watch -x run # Or `cargo run` for a single run without auto-reload.
 
 Or use the VS Code "Run Server" task for auto-reload on save.
 
+### Client
+
+```bash
+cd client
+npm run dev
+```
+
+Or use the VS Code "Run Client" task.
+
+### Both at once
+
+In VS Code, run the "Run Client and Server" task (`Ctrl+Shift+P` → `Tasks: Run Task`) to start the server and client together, each with auto-reload on save.
+
 ## API
 
 The API is JSON, backed by Postgres.
 
 `/transactions`:
 
-- `GET /transactions` — list transactions, optionally filtered with `?date=YYYY-MM-DD` and/or `?merchant=`.
+- `GET /transactions` — list transactions, optionally filtered with `?date=YYYY-MM-DD`, `?start_date=`/`?end_date=` (inclusive range), `?merchant=`, and/or `?search=` (case-insensitive match against merchant, category, or amount). Accepts `?order=` (`date` [default], `inverse_date`, `amount`, `inverse_amount`).
 - `GET /transactions/{id}` — fetch a single transaction.
 - `POST /transactions` — create a transaction (`date`, `merchant`, `amount`, `category_id`, `account`).
 - `PATCH /transactions/{id}` — partially update a transaction (only the fields you send change).
 - `DELETE /transactions/{id}` — delete a transaction.
+- `GET /transactions/download` — download the same filtered/sorted transactions as `GET /transactions`, rendered as a file. Accepts the same query params plus `?format=` (`csv` or `xlsx`, required).
+- `POST /transactions/import` — upload a budget file (multipart, field `file`, 10 MB max) to import as transactions. Kicks off an async job and returns `202 Accepted` with a `Location` header pointing at the job. Requires the `claude` CLI (see [Install](#install)).
+- `GET /transactions/import/jobs/{id}` — poll an import job's status (`pending`, `running`, `succeeded`, `failed`) and, once terminal, its `created_count`/`failed_count`/`skipped_count`/`error_message`.
 
 Every transaction response includes its joined category: `category_name_en`, `category_name_fr`, and `category_type` alongside `category_id`. `category_id` must reference an existing category (enforced by a foreign key).
 
@@ -69,12 +124,35 @@ Every transaction response includes its joined category: `category_name_en`, `ca
 
 ## Tests
 
+Server only — the client has no tests yet.
+
 ```bash
 cd server
 cargo test
 ```
 
 Each test runs against its own throwaway Postgres database (auto-migrated, auto-dropped), so your real data is untouched.
+
+## Lint & Format
+
+### Server
+
+```bash
+cd server
+cargo fmt
+```
+
+### Client
+
+```bash
+cd client
+npm run lint    # oxlint
+npm run format  # prettier
+```
+
+### Both at once
+
+In VS Code, run the "Format" task (`Ctrl+Shift+P` → `Tasks: Run Task`) to format both server and client at once.
 
 ## License
 


### PR DESCRIPTION
Docs: Document client setup, import CLI dependency, and undocumented endpoints in README

Adds client install/configuration/run steps, the Claude Code CLI prerequisite for the import job, the download/import/job-status endpoints, DEFAULT_LANGUAGE, and lint/format commands.

Part of #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded installation and setup instructions for PostgreSQL, authentication, server/client configuration, and environment variables.
  * Added guidance for running the server and client independently or together.
  * Documented transaction filtering, sorting, downloads, asynchronous imports, and import-status polling.
  * Updated testing, linting, and formatting instructions for client and combined workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->