### PR TITLE
API: Persist transactions submitted from AddTransactionModal

### DIFF
--- a/client/src/features/transactions/AddTransactionModal.tsx
+++ b/client/src/features/transactions/AddTransactionModal.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import { useCategories } from '../categories/use-categories';
-import { createTransaction } from './api';
-import { addTransactionSucceededToast } from '../../lib/toast';
+import { useCreateTransaction } from './use-create-transaction';
 import './AddTransactionModal.css';
 
 /**
@@ -14,6 +12,23 @@ import './AddTransactionModal.css';
  * one — this is the value manually-added transactions carry until accounts exist.
  */
 const MANUAL_ACCOUNT = 'Manual entry';
+
+/**
+ * The amount input accepts a comma or a period as the decimal separator (French keyboards
+ * produce a comma), but a value with both — e.g. "1,234.56" — or a single separator followed by
+ * 3+ digits — e.g. "1,234" — reads as thousands-grouped. Guessing which separator was meant would
+ * silently change the amount rather than fail loudly, so both are rejected instead. Returns the
+ * amount as a server-compatible decimal string ("1234.56"), or null if it's ambiguous.
+ */
+const normalizeAmount = (rawAmount: string): string | null => {
+  const separators = rawAmount.match(/[.,]/g) ?? [];
+  if (separators.length > 1) return null;
+
+  const [wholePart, fractionPart] = rawAmount.split(/[.,]/);
+  if (fractionPart !== undefined && fractionPart.length > 2) return null;
+
+  return fractionPart === undefined ? wholePart : `${wholePart}.${fractionPart}`;
+};
 
 type AddTransactionModalProps = {
   open: boolean;
@@ -29,7 +44,6 @@ export const AddTransactionModal = ({
 }: AddTransactionModalProps) => {
   const { t, i18n } = useTranslation();
   const { data: categories } = useCategories();
-  const queryClient = useQueryClient();
   const [amount, setAmount] = useState('');
   const [merchant, setMerchant] = useState('');
   const [date, setDate] = useState('');
@@ -37,26 +51,7 @@ export const AddTransactionModal = ({
   const [error, setError] = useState('');
   const dialogRef = useRef<HTMLDivElement>(null);
 
-  const createTransactionMutation = useMutation({
-    mutationFn: createTransaction,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['transactions'] });
-      addTransactionSucceededToast();
-      setAmount('');
-      setMerchant('');
-      setDate('');
-      setCategory('');
-      onClose();
-    },
-    onError: () => {
-      setError(
-        t(
-          'transactions.add.failed',
-          'Failed to add the transaction. Please try again.',
-        ),
-      );
-    },
-  });
+  const createTransactionMutation = useCreateTransaction();
 
   useEffect(() => {
     if (!open) return;
@@ -120,16 +115,44 @@ export const AddTransactionModal = ({
       return;
     }
 
+    const normalizedAmount = normalizeAmount(amount.trim());
+    if (normalizedAmount === null) {
+      setError(
+        t(
+          'transactions.add.invalidAmount',
+          'Enter a plain amount, e.g. 12.50, without thousands separators.',
+        ),
+      );
+      return;
+    }
+
     setError('');
-    createTransactionMutation.mutate({
-      date,
-      merchant: merchant.trim(),
-      // Decimal parsing on the server expects a period, but the input allows a comma too (French
-      // locale keyboards produce one).
-      amount: amount.trim().replace(',', '.'),
-      category_id: Number(category),
-      account: MANUAL_ACCOUNT,
-    });
+    createTransactionMutation.mutate(
+      {
+        date,
+        merchant: merchant.trim(),
+        amount: normalizedAmount,
+        category_id: Number(category),
+        account: MANUAL_ACCOUNT,
+      },
+      {
+        onSuccess: () => {
+          setAmount('');
+          setMerchant('');
+          setDate('');
+          setCategory('');
+          onClose();
+        },
+        onError: () => {
+          setError(
+            t(
+              'transactions.add.failed',
+              'Failed to add the transaction. Please try again.',
+            ),
+          );
+        },
+      },
+    );
   };
 
   return (

--- a/client/src/features/transactions/AddTransactionModal.tsx
+++ b/client/src/features/transactions/AddTransactionModal.tsx
@@ -1,11 +1,19 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import { useCategories } from '../categories/use-categories';
-import { notImplementedToast } from '../../lib/toast';
+import { createTransaction } from './api';
+import { addTransactionSucceededToast } from '../../lib/toast';
 import './AddTransactionModal.css';
+
+/**
+ * The form doesn't collect an account (there's no multi-account UI yet), but the API requires
+ * one — this is the value manually-added transactions carry until accounts exist.
+ */
+const MANUAL_ACCOUNT = 'Manual entry';
 
 type AddTransactionModalProps = {
   open: boolean;
@@ -21,12 +29,34 @@ export const AddTransactionModal = ({
 }: AddTransactionModalProps) => {
   const { t, i18n } = useTranslation();
   const { data: categories } = useCategories();
+  const queryClient = useQueryClient();
   const [amount, setAmount] = useState('');
   const [merchant, setMerchant] = useState('');
   const [date, setDate] = useState('');
   const [category, setCategory] = useState('');
   const [error, setError] = useState('');
   const dialogRef = useRef<HTMLDivElement>(null);
+
+  const createTransactionMutation = useMutation({
+    mutationFn: createTransaction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['transactions'] });
+      addTransactionSucceededToast();
+      setAmount('');
+      setMerchant('');
+      setDate('');
+      setCategory('');
+      onClose();
+    },
+    onError: () => {
+      setError(
+        t(
+          'transactions.add.failed',
+          'Failed to add the transaction. Please try again.',
+        ),
+      );
+    },
+  });
 
   useEffect(() => {
     if (!open) return;
@@ -90,9 +120,16 @@ export const AddTransactionModal = ({
       return;
     }
 
-    // API integration will be added in a later issue.
-    notImplementedToast();
-    onClose();
+    setError('');
+    createTransactionMutation.mutate({
+      date,
+      merchant: merchant.trim(),
+      // Decimal parsing on the server expects a period, but the input allows a comma too (French
+      // locale keyboards produce one).
+      amount: amount.trim().replace(',', '.'),
+      category_id: Number(category),
+      account: MANUAL_ACCOUNT,
+    });
   };
 
   return (
@@ -209,6 +246,7 @@ export const AddTransactionModal = ({
             type="button"
             className="modal-button modal-button--primary"
             onClick={handleSubmit}
+            disabled={createTransactionMutation.isPending}
           >
             {t('transactions.add.submit', 'Add transaction')}
           </button>

--- a/client/src/features/transactions/api.ts
+++ b/client/src/features/transactions/api.ts
@@ -1,0 +1,18 @@
+import { apiFetch } from '../../lib/api-client';
+import type { Transaction } from './types';
+
+export interface NewTransaction {
+  date: string;
+  merchant: string;
+  amount: string;
+  category_id: number;
+  account: string;
+}
+
+export const createTransaction = (
+  newTransaction: NewTransaction,
+): Promise<Transaction> =>
+  apiFetch<Transaction>('/transactions', {
+    method: 'POST',
+    body: JSON.stringify(newTransaction),
+  });

--- a/client/src/features/transactions/use-create-transaction.ts
+++ b/client/src/features/transactions/use-create-transaction.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createTransaction } from './api';
+import { addTransactionSucceededToast } from '../../lib/toast';
+
+export const useCreateTransaction = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createTransaction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['transactions'] });
+      addTransactionSucceededToast();
+    },
+  });
+};

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -76,6 +76,7 @@ export const en = {
     cancel: 'Cancel',
     close: 'Close',
     required: 'All fields are required.',
+    failed: 'Failed to add the transaction. Please try again.',
   },
 
     toolbar: {
@@ -144,6 +145,7 @@ export const en = {
     onboardingFailed: 'Could not set up your household. Please try again.',
     joinCodeNotFound: 'No household matches this join code.',
     downloadFailed: 'Failed to download transactions.',
+    addTransactionSucceeded: 'Transaction added.',
     importStarted: 'Import started — this can take a minute.',
     importFailed: 'Failed to import transactions.',
     importSucceeded_one: 'Imported {{count}} transaction.',

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -76,6 +76,7 @@ export const en = {
     cancel: 'Cancel',
     close: 'Close',
     required: 'All fields are required.',
+    invalidAmount: 'Enter a plain amount, e.g. 12.50, without thousands separators.',
     failed: 'Failed to add the transaction. Please try again.',
   },
 

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -78,6 +78,7 @@ export const fr: typeof en = {
     cancel: 'Annuler',
     close: 'Fermer',
     required: 'Tous les champs sont obligatoires.',
+    failed: "Impossible d'ajouter la transaction. Réessaie.",
   },
 
     toolbar: {
@@ -146,6 +147,7 @@ export const fr: typeof en = {
     onboardingFailed: 'Impossible de configurer ton ménage. Réessaie.',
     joinCodeNotFound: 'Aucun ménage ne correspond à ce code d’invitation.',
     downloadFailed: 'Échec du téléchargement des transactions.',
+    addTransactionSucceeded: 'Transaction ajoutée.',
     importStarted: 'Importation commencée — ça peut prendre une minute.',
     importFailed: "Échec de l'importation des transactions.",
     importSucceeded_one: '{{count}} transaction importée.',

--- a/client/src/i18n/locales/fr.ts
+++ b/client/src/i18n/locales/fr.ts
@@ -78,6 +78,8 @@ export const fr: typeof en = {
     cancel: 'Annuler',
     close: 'Fermer',
     required: 'Tous les champs sont obligatoires.',
+    invalidAmount:
+      'Entre un montant simple, par exemple 12,50, sans séparateur de milliers.',
     failed: "Impossible d'ajouter la transaction. Réessaie.",
   },
 

--- a/client/src/lib/toast.ts
+++ b/client/src/lib/toast.ts
@@ -17,6 +17,9 @@ export const joinCodeNotFoundToast = () =>
 export const downloadFailedToast = () =>
   toast.error(i18n.t('toast.downloadFailed'));
 
+export const addTransactionSucceededToast = () =>
+  toast.success(i18n.t('toast.addTransactionSucceeded'));
+
 export const importStartedToast = () => toast(i18n.t('toast.importStarted'));
 
 export const importFailedToast = () =>


### PR DESCRIPTION
Wires the Add transaction form to POST /transactions, invalidates the transactions query on success (list updates live), and shows a success toast. On failure the modal stays open with an inline error instead of losing the entered data.

Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to save new transactions from the add-transaction modal.
  - Displays a success confirmation after a transaction is added.
  - Refreshes the transaction list automatically after submission.
  - Prevents duplicate submissions while the request is processing.

- **Bug Fixes**
  - Added clear error messaging when saving a transaction fails.

- **Localization**
  - Added English and French translations for success and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->